### PR TITLE
✨ Add scannable QR code for joining leagues

### DIFF
--- a/frontend/app/app/league/[leagueId]/leaderboard/invite-prompt.tsx
+++ b/frontend/app/app/league/[leagueId]/leaderboard/invite-prompt.tsx
@@ -5,6 +5,8 @@ import { Button } from "@nextui-org/react"
 import toast, { Toaster } from "react-hot-toast"
 import { copyToClipboard } from "@/app/util/clipboard"
 import { BUTTON_CLASS } from "@/app/util/css-classes"
+import { inviteUrl } from "@/app/util/leagues"
+import InviteQRCode from "@/app/components/leaderboard/invite-qr-code"
 
 interface InvitePromptProps {
     leagueId: string
@@ -13,10 +15,10 @@ interface InvitePromptProps {
 
 export default function InvitePrompt({ leagueId, leagueName }: InvitePromptProps): React.JSX.Element {
     const [copied, setCopied] = useState(false)
-    const inviteUrl = `https://www.predictaball.live/league/${leagueId}/join`
+    const url = inviteUrl(leagueId)
 
     async function copy() {
-        const ok = await copyToClipboard(inviteUrl)
+        const ok = await copyToClipboard(url)
         if (ok) {
             setCopied(true)
             toast.success("Invite link copied")
@@ -34,8 +36,11 @@ export default function InvitePrompt({ leagueId, leagueName }: InvitePromptProps
                     You&apos;re the only one in &ldquo;{leagueName}&rdquo;
                 </h3>
                 <p className="mt-2 text-sm text-slate-600 dark:text-gray-300">
-                    Share the invite link to get the league going. Friends can sign up straight from the link if they&apos;re new.
+                    Share the invite link or QR code to get the league going. Friends can sign up straight from the link if they&apos;re new.
                 </p>
+                <div className="mt-4 flex justify-center">
+                    <InviteQRCode leagueId={leagueId} size={160}/>
+                </div>
                 <Button onPress={copy} radius="full" className={"mt-4 " + BUTTON_CLASS}>
                     {copied ? "Copied!" : "Copy invite link"}
                 </Button>

--- a/frontend/app/app/league/[leagueId]/leaderboard/just-created-modal.tsx
+++ b/frontend/app/app/league/[leagueId]/leaderboard/just-created-modal.tsx
@@ -6,6 +6,8 @@ import { useRouter, useSearchParams } from "next/navigation"
 import toast, { Toaster } from "react-hot-toast"
 import { copyToClipboard } from "@/app/util/clipboard"
 import { BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/app/util/css-classes"
+import { inviteUrl } from "@/app/util/leagues"
+import InviteQRCode from "@/app/components/leaderboard/invite-qr-code"
 
 interface JustCreatedModalProps {
     leagueId: string
@@ -19,7 +21,7 @@ export default function JustCreatedModal({ leagueId, leagueName }: JustCreatedMo
     const { isOpen, onOpen, onClose } = useDisclosure()
     const [copied, setCopied] = useState(false)
 
-    const inviteUrl = `https://www.predictaball.live/league/${leagueId}/join`
+    const url = inviteUrl(leagueId)
 
     useEffect(() => {
         if (shouldOpen) onOpen()
@@ -35,7 +37,7 @@ export default function JustCreatedModal({ leagueId, leagueName }: JustCreatedMo
     }
 
     async function copy() {
-        const ok = await copyToClipboard(inviteUrl)
+        const ok = await copyToClipboard(url)
         if (ok) {
             setCopied(true)
             toast.success("Invite link copied")
@@ -60,10 +62,13 @@ export default function JustCreatedModal({ leagueId, leagueName }: JustCreatedMo
                     </ModalHeader>
                     <ModalBody className="space-y-3">
                         <p className="text-sm text-slate-600 dark:text-gray-300">
-                            Share this link with friends to invite them. If they&apos;re new, they can sign up straight from the link.
+                            Share this link with friends to invite them, or let them scan the QR code. If they&apos;re new, they can sign up straight from the link.
                         </p>
+                        <div className="flex justify-center py-1">
+                            <InviteQRCode leagueId={leagueId}/>
+                        </div>
                         <div className="rounded-xl border border-slate-200 dark:border-white/10 bg-slate-50 dark:bg-white/5 px-3 py-2.5">
-                            <p className="text-xs text-slate-500 dark:text-gray-400 break-all font-mono">{inviteUrl}</p>
+                            <p className="text-xs text-slate-500 dark:text-gray-400 break-all font-mono">{url}</p>
                         </div>
                         <p className="text-xs text-slate-500 dark:text-gray-400">
                             You can find this link any time via the <span className="font-semibold text-slate-700 dark:text-gray-200">Invite</span> button at the top.

--- a/frontend/app/app/league/[leagueId]/leaderboard/share.tsx
+++ b/frontend/app/app/league/[leagueId]/leaderboard/share.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { copyToClipboard } from "@/app/util/clipboard"
-import { BRAND_GHOST_BUTTON_CLASS } from "@/app/util/css-classes"
-import { Button } from "@nextui-org/react"
+import { BRAND_GHOST_BUTTON_CLASS, BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/app/util/css-classes"
+import { Button, Modal, ModalBody, ModalContent, ModalHeader, useDisclosure } from "@nextui-org/react"
 import toast, { Toaster } from "react-hot-toast"
-import React from "react";
-import { isManagedLeague } from "@/app/util/leagues";
+import React, { useState } from "react";
+import { inviteUrl, isManagedLeague } from "@/app/util/leagues";
 import { LeagueKindEnum } from "@/client";
+import InviteQRCode from "@/app/components/leaderboard/invite-qr-code";
 
 function ShareIcon(): React.JSX.Element {
     return (
@@ -20,10 +21,16 @@ function ShareIcon(): React.JSX.Element {
 }
 
 export default function Share({leagueId, kind}: { leagueId: string; kind: LeagueKindEnum}): React.JSX.Element {
-    const shareInvite = () => {
-        copyToClipboard(`https://www.predictaball.live/league/${leagueId}/join`).then( didCopy => {
+    const { isOpen, onOpen, onClose } = useDisclosure()
+    const [copied, setCopied] = useState(false)
+    const url = inviteUrl(leagueId)
+
+    const copy = () => {
+        copyToClipboard(url).then(didCopy => {
             if (didCopy) {
+                setCopied(true)
                 toast.success("Copied League Invite Link To Clipboard", {duration: 4000})
+                setTimeout(() => setCopied(false), 2000)
             } else {
                 toast.error("Failed To Copy League Invite Link")
             }
@@ -35,9 +42,35 @@ export default function Share({leagueId, kind}: { leagueId: string; kind: League
     return (
         <>
             <Toaster/>
-            <Button onPress={shareInvite} size="sm" radius="full" className={BRAND_GHOST_BUTTON_CLASS} startContent={<ShareIcon/>}>
+            <Button onPress={onOpen} size="sm" radius="full" className={BRAND_GHOST_BUTTON_CLASS} startContent={<ShareIcon/>}>
                 Invite
             </Button>
+
+            <Modal isOpen={isOpen} onClose={onClose} placement="center" backdrop="blur" size="sm">
+                <ModalContent>
+                    <ModalHeader className="flex flex-col gap-1">
+                        <span className="text-xs font-semibold tracking-[0.3em] text-cyan-600/90 dark:text-cyan-300/80 uppercase">League invite</span>
+                        <h2 className="text-xl font-black tracking-tight">Invite friends to join</h2>
+                    </ModalHeader>
+                    <ModalBody className="items-center space-y-4 pb-6">
+                        <p className="text-center text-sm text-slate-600 dark:text-gray-300">
+                            Scan this QR code to join the league, or share the link below.
+                        </p>
+                        <InviteQRCode leagueId={leagueId}/>
+                        <div className="w-full rounded-xl border border-slate-200 dark:border-white/10 bg-slate-50 dark:bg-white/5 px-3 py-2.5">
+                            <p className="text-xs text-slate-500 dark:text-gray-400 break-all font-mono">{url}</p>
+                        </div>
+                        <div className="flex w-full gap-2">
+                            <Button onPress={onClose} variant="light" radius="full" className={"flex-1 " + GHOST_BUTTON_CLASS}>
+                                Close
+                            </Button>
+                            <Button onPress={copy} radius="full" className={"flex-1 " + BUTTON_CLASS}>
+                                {copied ? "Copied!" : "Copy link"}
+                            </Button>
+                        </div>
+                    </ModalBody>
+                </ModalContent>
+            </Modal>
         </>
     )
 }

--- a/frontend/app/components/leaderboard/invite-qr-code.tsx
+++ b/frontend/app/components/leaderboard/invite-qr-code.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import React from "react"
+import { QRCodeSVG } from "qrcode.react"
+import { inviteUrl } from "@/app/util/leagues"
+
+interface InviteQRCodeProps {
+    leagueId: string
+    size?: number
+}
+
+// A scannable QR code encoding the league's invite link. Scanning it opens the
+// same /league/[leagueId]/join page the "Invite" link points to. QR codes need a
+// light background with dark modules to scan reliably, so we always render on
+// white regardless of theme.
+export default function InviteQRCode({ leagueId, size = 200 }: InviteQRCodeProps): React.JSX.Element {
+    return (
+        <div className="inline-flex rounded-2xl bg-white p-4 shadow-lg shadow-slate-900/10 ring-1 ring-slate-900/5">
+            <QRCodeSVG
+                value={inviteUrl(leagueId)}
+                size={size}
+                level="M"
+                marginSize={0}
+                bgColor="#ffffff"
+                fgColor="#0f172a"
+                aria-label="QR code to join this league"
+            />
+        </div>
+    )
+}

--- a/frontend/app/util/leagues.ts
+++ b/frontend/app/util/leagues.ts
@@ -5,3 +5,9 @@ import { LeagueKindEnum } from "@/client"
 export function isManagedLeague(kind: LeagueKindEnum): boolean {
     return kind !== LeagueKindEnum.User
 }
+
+// The canonical invite link for a league. New users can sign up straight from it,
+// and it's the same URL we encode into the scannable QR code.
+export function inviteUrl(leagueId: string): string {
+    return `https://www.predictaball.live/league/${leagueId}/join`
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "next": "^15.5.14",
         "next-auth": "^5.0.0-beta.31",
         "next-themes": "^0.4.6",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.5",
         "react-countup": "^6.5.3",
         "react-dom": "^19.2.5",
@@ -10381,6 +10382,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "next": "^15.5.14",
     "next-auth": "^5.0.0-beta.31",
     "next-themes": "^0.4.6",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.5",
     "react-countup": "^6.5.3",
     "react-dom": "^19.2.5",


### PR DESCRIPTION
Add a QR code encoding the league invite link so friends can join by
scanning instead of copying a link.

- Add reusable InviteQRCode component (qrcode.react) plus a shared
  inviteUrl() helper for the canonical join link
- Turn the leaderboard "Invite" button into a modal showing the QR code
  alongside the copy-link action
- Surface the QR code in the post-creation modal and the solo-league
  invite prompt

https://claude.ai/code/session_0193YphPL8RCch3tB2Up5vZq