### PR TITLE
fix: constrain landing page pitch motif to viewport height

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -37,7 +37,7 @@ export default async function Home(): Promise<React.JSX.Element> {
 
             <section className="relative flex flex-col items-center px-6 lg:px-10 py-24 min-h-svh overflow-hidden">
                 <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.12),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.10),transparent_55%)]"/>
-                <PitchPerspective/>
+                <div className="pointer-events-none absolute inset-x-0 top-0 h-svh"><PitchPerspective/></div>
 
                 <HowItWorks>
                     <div className="mt-24 relative overflow-hidden rounded-3xl bg-gradient-to-r from-blue-600/20 via-cyan-500/20 to-teal-400/20 p-[1px]">


### PR DESCRIPTION
PitchPerspective was sizing itself off the section's full content
height (min-h-svh, much taller than the viewport on mobile due to
the How It Works content), so the mobile portrait pitch got squashed
into a flat, landscape-looking sliver. Wrap it in a fixed h-svh
container, matching the pattern used on the app and leaderboard pages.

https://claude.ai/code/session_01Rh1bwTTKLUQnYiGxaAYLZM