### PR TITLE
feat: sleek "Page X of Y" pagination + fix scroll-jump on page change

### DIFF
--- a/frontend/app/app/match/[matchId]/predictions/predictions.tsx
+++ b/frontend/app/app/match/[matchId]/predictions/predictions.tsx
@@ -1,14 +1,15 @@
 'use client'
 
-import React, {useState} from "react";
+import React, {useRef, useState} from "react";
 import Link from "next/link";
 import {useRouter} from "next/navigation";
 import {League, Match, MatchRoundEnum, MatchStateEnum, PredictionWithUser} from "@/client";
 import PredictionData from "@/app/app/match/[matchId]/predictions/prediction";
-import {Pagination, Select, SelectItem} from "@nextui-org/react"
+import {Select, SelectItem} from "@nextui-org/react"
+import Pagination from "@/app/components/pagination"
 import BackButton from "@/app/components/back-button"
 import useWindowDimensions from "@/app/hooks/use-window-dimension";
-import {BUTTON_CLASS, SECTION_EYEBROW} from "@/app/util/css-classes";
+import {SECTION_EYEBROW} from "@/app/util/css-classes";
 import FocusedGlobeClient from "@/app/components/flags/focused-globe-client";
 import {FlagImage} from "@/app/components/predictions/flag-image";
 import {LocalTime} from "@/app/components/predictions/local-time";
@@ -88,6 +89,7 @@ export default function Predictions(
     const [currentPage, setCurrentPage] = useState(0)
     const windowsSize = useWindowDimensions()
     const itemsPerPage = windowsSize.height !== undefined ? Math.max((Math.round(windowsSize.height / 80)) - 5, 1) : 5
+    const topRef = useRef<HTMLDivElement>(null)
 
     const getPaginatedPredictions = (leaderboard: PredictionWithUser[]) => {
         const startIndex = currentPage * itemsPerPage;
@@ -96,6 +98,8 @@ export default function Predictions(
 
     const handlePageChange = (page: number) => {
         setCurrentPage(page - 1);
+        // Bring the reader back to the first prediction on the new page.
+        topRef.current?.scrollIntoView({behavior: "smooth", block: "start"})
     };
 
     const totalPages = Math.ceil(props.predictions.length / itemsPerPage);
@@ -159,7 +163,7 @@ export default function Predictions(
                             </Select>
                         )}
                     </div>
-                    <div className="flex flex-col items-center">
+                    <div ref={topRef} className="flex flex-col items-center scroll-mt-6">
                         {getPaginatedPredictions(props.predictions).map((predictionWithUser, index) => (
                             <PredictionData
                                 key={predictionWithUser.user.userId}
@@ -171,13 +175,7 @@ export default function Predictions(
                     </div>
                     {totalPages > 1 &&
                         <div className="flex justify-center pt-2">
-                            <Pagination showControls radius="full" total={totalPages} initialPage={1}
-                                        onChange={handlePageChange}
-                                        classNames={{
-                                            cursor: BUTTON_CLASS,
-                                            item: "bg-transparent text-slate-700 dark:text-gray-200 hover:bg-slate-900/10 dark:hover:bg-white/10 transition-colors"
-                                        }}
-                            />
+                            <Pagination page={currentPage + 1} total={totalPages} onChange={handlePageChange}/>
                         </div>}
                 </section>
             </div>

--- a/frontend/app/components/leaderboard/leaderboard-pagination.tsx
+++ b/frontend/app/components/leaderboard/leaderboard-pagination.tsx
@@ -2,9 +2,8 @@
 
 import {LeaderboardInner} from "@/client"
 import LeaderboardEntry from "./leaderboard-entry"
-import React, {useState} from "react"
-import {Pagination} from "@nextui-org/react";
-import {BUTTON_CLASS} from "@/app/util/css-classes";
+import React, {useEffect, useRef, useState} from "react"
+import Pagination from "@/app/components/pagination"
 import useWindowDimensions from "@/app/hooks/use-window-dimension";
 
 interface LeaderboardPaginationProps {
@@ -19,6 +18,7 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
     const [currentPage, setCurrentPage] = useState(0)
     const windowsSize = useWindowDimensions()
     const itemsPerPage = windowsSize.height !== undefined ? Math.max((Math.round(windowsSize.height / 100)) - 1, 1) : 10
+    const topRef = useRef<HTMLDivElement>(null)
 
     const getPaginatedLeaderboard = (leaderboard: any[]) => {
         if (!props.shouldPaginate) {
@@ -28,13 +28,24 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
         return leaderboard.slice(startIndex, startIndex + itemsPerPage);
     };
 
-    const handlePageChange = (page: number) => {
-        setCurrentPage(page - 1);
-    };
-
     const totalPages = Math.ceil(props.leaderboardInners.length / itemsPerPage);
 
+    // Keep the active page in range if the viewport (and therefore page size) shrinks.
+    useEffect(() => {
+        if (currentPage > totalPages - 1) {
+            setCurrentPage(Math.max(totalPages - 1, 0))
+        }
+    }, [currentPage, totalPages])
+
+    const handlePageChange = (page: number) => {
+        setCurrentPage(page - 1);
+        // Return the reader to the top of the list rather than leaving them
+        // stranded at the bottom where the controls live.
+        topRef.current?.scrollIntoView({behavior: "smooth", block: "start"})
+    };
+
     return <>
+        <div ref={topRef} className="scroll-mt-6"/>
         {getPaginatedLeaderboard(props.leaderboardInners).map((entry, index) => (
             <LeaderboardEntry
                 key={index}
@@ -46,12 +57,11 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
         ))}
         {props.shouldPaginate && totalPages > 1 &&
             <div className="sticky bottom-4 mt-4 flex justify-center pointer-events-none">
-                <Pagination showControls radius="full" total={totalPages} initialPage={1} onChange={handlePageChange}
-                            className="pointer-events-auto rounded-full bg-white/70 dark:bg-gray-900/70 backdrop-blur-md border border-slate-200/70 dark:border-white/10 shadow-lg shadow-slate-900/5 p-1"
-                            classNames={{
-                                cursor: BUTTON_CLASS,
-                                item: "bg-transparent text-slate-700 dark:text-gray-200 hover:bg-slate-900/10 dark:hover:bg-white/10 transition-colors"
-                            }}
+                <Pagination
+                    page={currentPage + 1}
+                    total={totalPages}
+                    onChange={handlePageChange}
+                    className="pointer-events-auto"
                 />
             </div>}
     </>

--- a/frontend/app/components/pagination.tsx
+++ b/frontend/app/components/pagination.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import React from "react"
+import {BUTTON_CLASS} from "@/app/util/css-classes"
+
+interface PaginationProps {
+    /** Current page, 1-indexed. */
+    page: number
+    /** Total number of pages. */
+    total: number
+    /** Called with the next 1-indexed page when the user navigates. */
+    onChange: (page: number) => void
+    /** Extra classes for the outer pill (e.g. positioning). */
+    className?: string
+}
+
+function ChevronLeft(): React.JSX.Element {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+            <path d="m15 18-6-6 6-6"/>
+        </svg>
+    )
+}
+
+function ChevronRight(): React.JSX.Element {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+            <path d="m9 18 6-6-6-6"/>
+        </svg>
+    )
+}
+
+/**
+ * Compact "Page X of Y" pagination — a floating glass pill with Prev / Next
+ * controls and a live page counter. Scales to any list length and stays
+ * cohesive with the brand gradient. Presentational only: callers own the
+ * paging state and any scroll behaviour.
+ */
+export default function Pagination(props: PaginationProps): React.JSX.Element {
+    const canPrev = props.page > 1
+    const canNext = props.page < props.total
+
+    const segment = "flex items-center gap-1.5 h-9 rounded-full text-sm font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+    const ghost = "text-slate-600 dark:text-gray-300 enabled:hover:bg-slate-900/10 dark:enabled:hover:bg-white/10"
+
+    return (
+        <nav
+            aria-label="Pagination"
+            className={`inline-flex items-stretch gap-1 p-1.5 rounded-full bg-white/70 dark:bg-gray-900/70 backdrop-blur-md border border-slate-200/70 dark:border-white/10 shadow-lg shadow-slate-900/5 ${props.className ?? ""}`}
+        >
+            <button
+                type="button"
+                aria-label="Previous page"
+                disabled={!canPrev}
+                onClick={() => canPrev && props.onChange(props.page - 1)}
+                className={`${segment} ${ghost} pl-3 pr-4`}
+            >
+                <ChevronLeft/>
+                <span>Prev</span>
+            </button>
+
+            <div
+                aria-live="polite"
+                className="flex items-center gap-1.5 h-9 px-4 rounded-full bg-slate-900/5 dark:bg-white/5 text-sm font-bold tabular-nums select-none"
+            >
+                <span className="bg-gradient-to-r from-blue-500 via-cyan-500 to-teal-500 dark:from-blue-400 dark:via-cyan-300 dark:to-teal-300 bg-clip-text text-transparent">
+                    {props.page}
+                </span>
+                <span className="text-slate-300 dark:text-gray-600">/</span>
+                <span className="text-slate-500 dark:text-gray-400">{props.total}</span>
+            </div>
+
+            <button
+                type="button"
+                aria-label="Next page"
+                disabled={!canNext}
+                onClick={() => canNext && props.onChange(props.page + 1)}
+                className={`${segment} ${BUTTON_CLASS} enabled:hover:scale-[1.02] disabled:shadow-none pl-4 pr-3`}
+            >
+                <span>Next</span>
+                <ChevronRight/>
+            </button>
+        </nav>
+    )
+}


### PR DESCRIPTION
## What & why

The pagination control was NextUI's default numbered widget, restyled inline in two places. This replaces it with a single, cohesive, reusable control and fixes a UX papercut where changing page left you stranded at the bottom of the list.

### 1. Redesigned, reusable pagination — "Page X of Y"
New `app/components/pagination.tsx`: a floating glass pill with **Prev / Next** and a live page counter. Built entirely from the existing brand tokens (the `blue→cyan→teal` gradient via `BUTTON_CLASS`, glass surfaces, slate text), so it sits naturally alongside the leaderboard rows and match header. Unlike the old numbered control it stays compact no matter how long the leaderboard gets.

It's now used in **both** places that paginate:
- the leaderboard (`leaderboard-pagination.tsx`)
- the match predictions list (`predictions.tsx`)

This was picked from three mocked options (numbered pill / Page X of Y / arrows + progress); "Page X of Y" was chosen for being the most professional and the most scalable.

### 2. Fixed the scroll-jump on page change
Previously, advancing a page (with the sticky leaderboard control especially) left the viewport anchored at the bottom, so you'd land mid-list rather than at the new page's first entry. Changing page now smoothly scrolls back to the top of the list (`scrollIntoView` + a `scroll-mt` offset for breathing room).

## Notes
- The new pill is presentational; callers own paging state and scroll behaviour.
- Added a small guard in `leaderboard-pagination.tsx` to keep the active page in range when the viewport (and therefore page size) shrinks.
- `@nextui-org/react`'s `Pagination` is no longer used anywhere.

## Verification
- `tsc --noEmit` passes clean.
- `next lint` clean for the touched files (the only warning is pre-existing in an unrelated component).
- Designs rendered and screenshotted against a representative leaderboard in both light and dark themes before implementing.

https://claude.ai/code/session_01JXSopXde4zjbEqfgzMWqrj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXSopXde4zjbEqfgzMWqrj)_