### PR TITLE
feat: sleek "Page X of Y" pagination — no scroll-jump, fixed position

### DIFF
--- a/frontend/app/app/match/[matchId]/predictions/predictions.tsx
+++ b/frontend/app/app/match/[matchId]/predictions/predictions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, {useRef, useState} from "react";
+import React, {useState} from "react";
 import Link from "next/link";
 import {useRouter} from "next/navigation";
 import {League, Match, MatchRoundEnum, MatchStateEnum, PredictionWithUser} from "@/client";
@@ -89,7 +89,6 @@ export default function Predictions(
     const [currentPage, setCurrentPage] = useState(0)
     const windowsSize = useWindowDimensions()
     const itemsPerPage = windowsSize.height !== undefined ? Math.max((Math.round(windowsSize.height / 80)) - 5, 1) : 5
-    const topRef = useRef<HTMLDivElement>(null)
 
     const getPaginatedPredictions = (leaderboard: PredictionWithUser[]) => {
         const startIndex = currentPage * itemsPerPage;
@@ -98,8 +97,6 @@ export default function Predictions(
 
     const handlePageChange = (page: number) => {
         setCurrentPage(page - 1);
-        // Bring the reader back to the first prediction on the new page.
-        topRef.current?.scrollIntoView({behavior: "smooth", block: "start"})
     };
 
     const totalPages = Math.ceil(props.predictions.length / itemsPerPage);
@@ -163,7 +160,7 @@ export default function Predictions(
                             </Select>
                         )}
                     </div>
-                    <div ref={topRef} className="flex flex-col items-center scroll-mt-6">
+                    <div className="flex flex-col items-center">
                         {getPaginatedPredictions(props.predictions).map((predictionWithUser, index) => (
                             <PredictionData
                                 key={predictionWithUser.user.userId}

--- a/frontend/app/app/match/[matchId]/predictions/predictions.tsx
+++ b/frontend/app/app/match/[matchId]/predictions/predictions.tsx
@@ -1,14 +1,15 @@
 'use client'
 
-import React, {useState} from "react";
+import React, {useRef, useState} from "react";
 import Link from "next/link";
 import {useRouter} from "next/navigation";
 import {League, Match, MatchRoundEnum, MatchStateEnum, PredictionWithUser} from "@/client";
 import PredictionData from "@/app/app/match/[matchId]/predictions/prediction";
-import {Pagination, Select, SelectItem} from "@nextui-org/react"
+import {Select, SelectItem} from "@nextui-org/react"
+import Pagination from "@/app/components/pagination"
 import BackButton from "@/app/components/back-button"
 import useWindowDimensions from "@/app/hooks/use-window-dimension";
-import {BUTTON_CLASS, SECTION_EYEBROW} from "@/app/util/css-classes";
+import {SECTION_EYEBROW} from "@/app/util/css-classes";
 import FocusedGlobeClient from "@/app/components/flags/focused-globe-client";
 import {FlagImage} from "@/app/components/predictions/flag-image";
 import {LocalTime} from "@/app/components/predictions/local-time";
@@ -88,6 +89,7 @@ export default function Predictions(
     const [currentPage, setCurrentPage] = useState(0)
     const windowsSize = useWindowDimensions()
     const itemsPerPage = windowsSize.height !== undefined ? Math.max((Math.round(windowsSize.height / 80)) - 5, 1) : 5
+    const topRef = useRef<HTMLDivElement>(null)
 
     const getPaginatedPredictions = (leaderboard: PredictionWithUser[]) => {
         const startIndex = currentPage * itemsPerPage;
@@ -96,6 +98,8 @@ export default function Predictions(
 
     const handlePageChange = (page: number) => {
         setCurrentPage(page - 1);
+        // Bring the reader back to the first prediction on the new page.
+        topRef.current?.scrollIntoView({behavior: "smooth", block: "start"})
     };
 
     const totalPages = Math.ceil(props.predictions.length / itemsPerPage);
@@ -159,7 +163,7 @@ export default function Predictions(
                             </Select>
                         )}
                     </div>
-                    <div className="flex flex-col items-center">
+                    <div ref={topRef} className="flex flex-col items-center scroll-mt-6">
                         {getPaginatedPredictions(props.predictions).map((predictionWithUser, index) => (
                             <PredictionData
                                 key={predictionWithUser.user.userId}
@@ -171,13 +175,7 @@ export default function Predictions(
                     </div>
                     {totalPages > 1 &&
                         <div className="flex justify-center pt-2">
-                            <Pagination showControls radius="full" total={totalPages} initialPage={1}
-                                        onChange={handlePageChange}
-                                        classNames={{
-                                            cursor: BUTTON_CLASS,
-                                            item: "bg-transparent text-slate-700 dark:text-gray-200 hover:bg-slate-900/10 dark:hover:bg-white/10 transition-colors"
-                                        }}
-                            />
+                            <Pagination page={currentPage + 1} total={totalPages} onChange={handlePageChange}/>
                         </div>}
                 </section>
             </div>

--- a/frontend/app/components/leaderboard/leaderboard-pagination.tsx
+++ b/frontend/app/components/leaderboard/leaderboard-pagination.tsx
@@ -2,7 +2,7 @@
 
 import {LeaderboardInner} from "@/client"
 import LeaderboardEntry from "./leaderboard-entry"
-import React, {useEffect, useRef, useState} from "react"
+import React, {useEffect, useState} from "react"
 import Pagination from "@/app/components/pagination"
 import useWindowDimensions from "@/app/hooks/use-window-dimension";
 
@@ -18,7 +18,6 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
     const [currentPage, setCurrentPage] = useState(0)
     const windowsSize = useWindowDimensions()
     const itemsPerPage = windowsSize.height !== undefined ? Math.max((Math.round(windowsSize.height / 100)) - 1, 1) : 10
-    const topRef = useRef<HTMLDivElement>(null)
 
     const getPaginatedLeaderboard = (leaderboard: any[]) => {
         if (!props.shouldPaginate) {
@@ -39,13 +38,11 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
 
     const handlePageChange = (page: number) => {
         setCurrentPage(page - 1);
-        // Return the reader to the top of the list rather than leaving them
-        // stranded at the bottom where the controls live.
-        topRef.current?.scrollIntoView({behavior: "smooth", block: "start"})
     };
 
+    const paginated = props.shouldPaginate && totalPages > 1
+
     return <>
-        <div ref={topRef} className="scroll-mt-6"/>
         {getPaginatedLeaderboard(props.leaderboardInners).map((entry, index) => (
             <LeaderboardEntry
                 key={index}
@@ -55,14 +52,17 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
                 form={props.formByUserId[entry.user.userId] ?? []}
             />
         ))}
-        {props.shouldPaginate && totalPages > 1 &&
-            <div className="sticky bottom-4 mt-4 flex justify-center pointer-events-none">
+        {paginated && <>
+            {/* Reserve room so the last row is never hidden behind the fixed control. */}
+            <div className="h-20"/>
+            <div className="fixed inset-x-0 bottom-4 z-30 flex justify-center pointer-events-none">
                 <Pagination
                     page={currentPage + 1}
                     total={totalPages}
                     onChange={handlePageChange}
                     className="pointer-events-auto"
                 />
-            </div>}
+            </div>
+        </>}
     </>
 }

--- a/frontend/app/components/leaderboard/leaderboard-pagination.tsx
+++ b/frontend/app/components/leaderboard/leaderboard-pagination.tsx
@@ -41,9 +41,14 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
     };
 
     const paginated = props.shouldPaginate && totalPages > 1
+    const pageEntries = getPaginatedLeaderboard(props.leaderboardInners)
+    // Pad short pages (i.e. the last one) up to a full page of rows so the
+    // document height never changes between pages. A changing height makes the
+    // browser clamp the scroll position, which reads as the list "jumping".
+    const fillerCount = paginated ? Math.max(itemsPerPage - pageEntries.length, 0) : 0
 
     return <>
-        {getPaginatedLeaderboard(props.leaderboardInners).map((entry, index) => (
+        {pageEntries.map((entry, index) => (
             <LeaderboardEntry
                 key={index}
                 entry={entry}
@@ -51,6 +56,15 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
                 disablePulse={false}
                 form={props.formByUserId[entry.user.userId] ?? []}
             />
+        ))}
+        {Array.from({length: fillerCount}).map((_, i) => (
+            // Invisible row that matches an entry's height exactly, keeping every
+            // page the same height. aria-hidden + inert so it's inert to AT/focus.
+            <div key={`filler-${i}`} aria-hidden inert className="invisible w-full max-w-2xl rounded-2xl p-[1px] mb-2.5">
+                <div className="flex items-center gap-3 rounded-2xl px-4 py-3">
+                    <div className="text-lg font-black">0</div>
+                </div>
+            </div>
         ))}
         {paginated && <>
             {/* Reserve room so the last row is never hidden behind the fixed control. */}

--- a/frontend/app/components/leaderboard/leaderboard-pagination.tsx
+++ b/frontend/app/components/leaderboard/leaderboard-pagination.tsx
@@ -2,9 +2,8 @@
 
 import {LeaderboardInner} from "@/client"
 import LeaderboardEntry from "./leaderboard-entry"
-import React, {useState} from "react"
-import {Pagination} from "@nextui-org/react";
-import {BUTTON_CLASS} from "@/app/util/css-classes";
+import React, {useEffect, useRef, useState} from "react"
+import Pagination from "@/app/components/pagination"
 import useWindowDimensions from "@/app/hooks/use-window-dimension";
 
 interface LeaderboardPaginationProps {
@@ -19,6 +18,7 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
     const [currentPage, setCurrentPage] = useState(0)
     const windowsSize = useWindowDimensions()
     const itemsPerPage = windowsSize.height !== undefined ? Math.max((Math.round(windowsSize.height / 100)) - 1, 1) : 10
+    const topRef = useRef<HTMLDivElement>(null)
 
     const getPaginatedLeaderboard = (leaderboard: any[]) => {
         if (!props.shouldPaginate) {
@@ -28,13 +28,24 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
         return leaderboard.slice(startIndex, startIndex + itemsPerPage);
     };
 
-    const handlePageChange = (page: number) => {
-        setCurrentPage(page - 1);
-    };
-
     const totalPages = Math.ceil(props.leaderboardInners.length / itemsPerPage);
 
+    // Keep the active page in range if the viewport (and therefore page size) shrinks.
+    useEffect(() => {
+        if (currentPage > totalPages - 1) {
+            setCurrentPage(Math.max(totalPages - 1, 0))
+        }
+    }, [currentPage, totalPages])
+
+    const handlePageChange = (page: number) => {
+        setCurrentPage(page - 1);
+        // Return the reader to the top of the list rather than leaving them
+        // stranded at the bottom where the controls live.
+        topRef.current?.scrollIntoView({behavior: "smooth", block: "start"})
+    };
+
     return <>
+        <div ref={topRef} className="scroll-mt-6"/>
         {getPaginatedLeaderboard(props.leaderboardInners).map((entry, index) => (
             <LeaderboardEntry
                 key={index}
@@ -46,12 +57,11 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
         ))}
         {props.shouldPaginate && totalPages > 1 &&
             <div className="sticky bottom-4 mt-4 flex justify-center pointer-events-none">
-                <Pagination showControls radius="full" total={totalPages} initialPage={1} onChange={handlePageChange}
-                            className="pointer-events-auto rounded-full bg-white/70 dark:bg-gray-900/70 backdrop-blur-md border border-slate-200/70 dark:border-white/10 shadow-lg shadow-slate-900/5 p-1"
-                            classNames={{
-                                cursor: BUTTON_CLASS,
-                                item: "bg-transparent text-slate-700 dark:text-gray-200 hover:bg-slate-900/10 dark:hover:bg-white/10 transition-colors"
-                            }}
+                <Pagination
+                    page={currentPage + 1}
+                    total={totalPages}
+                    onChange={handlePageChange}
+                    className="pointer-events-auto"
                 />
             </div>}
     </>

--- a/frontend/app/components/pagination.tsx
+++ b/frontend/app/components/pagination.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import React from "react"
+import {BUTTON_CLASS} from "@/app/util/css-classes"
+
+interface PaginationProps {
+    /** Current page, 1-indexed. */
+    page: number
+    /** Total number of pages. */
+    total: number
+    /** Called with the next 1-indexed page when the user navigates. */
+    onChange: (page: number) => void
+    /** Extra classes for the outer pill (e.g. positioning). */
+    className?: string
+}
+
+function ChevronLeft(): React.JSX.Element {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+            <path d="m15 18-6-6 6-6"/>
+        </svg>
+    )
+}
+
+function ChevronRight(): React.JSX.Element {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+            <path d="m9 18 6-6-6-6"/>
+        </svg>
+    )
+}
+
+/**
+ * Compact "Page X of Y" pagination — a floating glass pill with Prev / Next
+ * controls and a live page counter. Scales to any list length and stays
+ * cohesive with the brand gradient. Presentational only: callers own the
+ * paging state and any scroll behaviour.
+ */
+export default function Pagination(props: PaginationProps): React.JSX.Element {
+    const canPrev = props.page > 1
+    const canNext = props.page < props.total
+
+    const segment = "flex items-center gap-1.5 h-9 rounded-full text-sm font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+    const ghost = "text-slate-600 dark:text-gray-300 enabled:hover:bg-slate-900/10 dark:enabled:hover:bg-white/10"
+
+    return (
+        <nav
+            aria-label="Pagination"
+            className={`inline-flex items-stretch gap-1 p-1.5 rounded-full bg-white/70 dark:bg-gray-900/70 backdrop-blur-md border border-slate-200/70 dark:border-white/10 shadow-lg shadow-slate-900/5 ${props.className ?? ""}`}
+        >
+            <button
+                type="button"
+                aria-label="Previous page"
+                disabled={!canPrev}
+                onClick={() => canPrev && props.onChange(props.page - 1)}
+                className={`${segment} ${ghost} pl-3 pr-4`}
+            >
+                <ChevronLeft/>
+                <span>Prev</span>
+            </button>
+
+            <div
+                aria-live="polite"
+                className="flex items-center gap-1.5 h-9 px-4 rounded-full bg-slate-900/5 dark:bg-white/5 text-sm font-bold tabular-nums select-none"
+            >
+                <span className="bg-gradient-to-r from-blue-500 via-cyan-500 to-teal-500 dark:from-blue-400 dark:via-cyan-300 dark:to-teal-300 bg-clip-text text-transparent">
+                    {props.page}
+                </span>
+                <span className="text-slate-300 dark:text-gray-600">/</span>
+                <span className="text-slate-500 dark:text-gray-400">{props.total}</span>
+            </div>
+
+            <button
+                type="button"
+                aria-label="Next page"
+                disabled={!canNext}
+                onClick={() => canNext && props.onChange(props.page + 1)}
+                className={`${segment} ${BUTTON_CLASS} enabled:hover:scale-[1.02] disabled:shadow-none pl-4 pr-3`}
+            >
+                <span>Next</span>
+                <ChevronRight/>
+            </button>
+        </nav>
+    )
+}


### PR DESCRIPTION
Re-raise of #74, targeted at `main`. Single, self-contained PR for the whole pagination change — it contains the complete work and **supersedes #73** (which can be closed). It also includes the constant-height fix that landed after #74 was merged into the feature branch.

## What this does
A new reusable pagination control plus the UX fixes, across the three files that own pagination.

### 1. New `Pagination` component (`app/components/pagination.tsx`)
A floating glass pill — **Prev / Next** with a live "X / Y" page counter — built entirely from the existing brand tokens (the `blue→cyan→teal` gradient via `BUTTON_CLASS`, glass surfaces, slate text). Stays compact no matter how long the list is. Used on both the league leaderboard and the match-predictions list.

### 2. No scroll on page change
Changing page no longer triggers any scroll. There are zero `scrollIntoView`/`scrollTo` calls left in the leaderboard/predictions path.

### 3. Pagination is pinned in place
The leaderboard control is `fixed` to the bottom-centre of the viewport (was `sticky`), so it no longer drifts upward on pages with fewer rows.

### 4. Constant page height
Short pages (the last one) are padded with invisible, inert filler rows so the document height never changes between pages — otherwise the browser clamps the scroll position when the page shrinks, which reads as the list jumping.

## Verification
Ran the real `LeaderboardPagination` in a dev server and drove it headless, measuring `window.scrollY` on every page change:
- `scrollY` holds constant across **all** pages, including the short last one.
- Zero scroll events, zero programmatic scroll calls.
- `tsc --noEmit` and `next lint` clean for the touched files.

> Scope note: the fixed-position treatment is leaderboard-only; the match-predictions list keeps its inline control (only the scroll removal applies there). Happy to make predictions fixed too if preferred.

https://claude.ai/code/session_01JXSopXde4zjbEqfgzMWqrj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXSopXde4zjbEqfgzMWqrj)_