### PR TITLE
fix: stop leaderboard pagination scrolling and pin it in place

### DIFF
--- a/frontend/app/app/match/[matchId]/predictions/predictions.tsx
+++ b/frontend/app/app/match/[matchId]/predictions/predictions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, {useRef, useState} from "react";
+import React, {useState} from "react";
 import Link from "next/link";
 import {useRouter} from "next/navigation";
 import {League, Match, MatchRoundEnum, MatchStateEnum, PredictionWithUser} from "@/client";
@@ -89,7 +89,6 @@ export default function Predictions(
     const [currentPage, setCurrentPage] = useState(0)
     const windowsSize = useWindowDimensions()
     const itemsPerPage = windowsSize.height !== undefined ? Math.max((Math.round(windowsSize.height / 80)) - 5, 1) : 5
-    const topRef = useRef<HTMLDivElement>(null)
 
     const getPaginatedPredictions = (leaderboard: PredictionWithUser[]) => {
         const startIndex = currentPage * itemsPerPage;
@@ -98,8 +97,6 @@ export default function Predictions(
 
     const handlePageChange = (page: number) => {
         setCurrentPage(page - 1);
-        // Bring the reader back to the first prediction on the new page.
-        topRef.current?.scrollIntoView({behavior: "smooth", block: "start"})
     };
 
     const totalPages = Math.ceil(props.predictions.length / itemsPerPage);
@@ -163,7 +160,7 @@ export default function Predictions(
                             </Select>
                         )}
                     </div>
-                    <div ref={topRef} className="flex flex-col items-center scroll-mt-6">
+                    <div className="flex flex-col items-center">
                         {getPaginatedPredictions(props.predictions).map((predictionWithUser, index) => (
                             <PredictionData
                                 key={predictionWithUser.user.userId}

--- a/frontend/app/components/leaderboard/leaderboard-pagination.tsx
+++ b/frontend/app/components/leaderboard/leaderboard-pagination.tsx
@@ -2,7 +2,7 @@
 
 import {LeaderboardInner} from "@/client"
 import LeaderboardEntry from "./leaderboard-entry"
-import React, {useEffect, useRef, useState} from "react"
+import React, {useEffect, useState} from "react"
 import Pagination from "@/app/components/pagination"
 import useWindowDimensions from "@/app/hooks/use-window-dimension";
 
@@ -18,7 +18,6 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
     const [currentPage, setCurrentPage] = useState(0)
     const windowsSize = useWindowDimensions()
     const itemsPerPage = windowsSize.height !== undefined ? Math.max((Math.round(windowsSize.height / 100)) - 1, 1) : 10
-    const topRef = useRef<HTMLDivElement>(null)
 
     const getPaginatedLeaderboard = (leaderboard: any[]) => {
         if (!props.shouldPaginate) {
@@ -39,14 +38,17 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
 
     const handlePageChange = (page: number) => {
         setCurrentPage(page - 1);
-        // Return the reader to the top of the list rather than leaving them
-        // stranded at the bottom where the controls live.
-        topRef.current?.scrollIntoView({behavior: "smooth", block: "start"})
     };
 
+    const paginated = props.shouldPaginate && totalPages > 1
+    const pageEntries = getPaginatedLeaderboard(props.leaderboardInners)
+    // Pad short pages (i.e. the last one) up to a full page of rows so the
+    // document height never changes between pages. A changing height makes the
+    // browser clamp the scroll position, which reads as the list "jumping".
+    const fillerCount = paginated ? Math.max(itemsPerPage - pageEntries.length, 0) : 0
+
     return <>
-        <div ref={topRef} className="scroll-mt-6"/>
-        {getPaginatedLeaderboard(props.leaderboardInners).map((entry, index) => (
+        {pageEntries.map((entry, index) => (
             <LeaderboardEntry
                 key={index}
                 entry={entry}
@@ -55,14 +57,26 @@ export default function LeaderboardPagination(props: LeaderboardPaginationProps)
                 form={props.formByUserId[entry.user.userId] ?? []}
             />
         ))}
-        {props.shouldPaginate && totalPages > 1 &&
-            <div className="sticky bottom-4 mt-4 flex justify-center pointer-events-none">
+        {Array.from({length: fillerCount}).map((_, i) => (
+            // Invisible row that matches an entry's height exactly, keeping every
+            // page the same height. aria-hidden + inert so it's inert to AT/focus.
+            <div key={`filler-${i}`} aria-hidden inert className="invisible w-full max-w-2xl rounded-2xl p-[1px] mb-2.5">
+                <div className="flex items-center gap-3 rounded-2xl px-4 py-3">
+                    <div className="text-lg font-black">0</div>
+                </div>
+            </div>
+        ))}
+        {paginated && <>
+            {/* Reserve room so the last row is never hidden behind the fixed control. */}
+            <div className="h-20"/>
+            <div className="fixed inset-x-0 bottom-4 z-30 flex justify-center pointer-events-none">
                 <Pagination
                     page={currentPage + 1}
                     total={totalPages}
                     onChange={handlePageChange}
                     className="pointer-events-auto"
                 />
-            </div>}
+            </div>
+        </>}
     </>
 }


### PR DESCRIPTION
Branched off current `main` (which already has the pagination redesign from #73). Two small fixes, two files, nothing else.

### 1. No scroll on page change
The redesign shipped with a `scrollIntoView` on every page change — that's the scrolling you were seeing on `main`. Removed from both the leaderboard and the match-predictions list. No `scrollIntoView` remains in the pagination path.

### 2. Pagination pinned in place
- The leaderboard control was `sticky`, so on a page with fewer rows it drifted upward to sit under the short list. It's now `fixed` to the bottom-centre of the viewport.
- Short pages are padded with invisible, inert filler rows so the document height never changes between pages. (A shrinking page makes the browser clamp the scroll position, which reads as the list jumping on the last page.)

## Verification
Drove the real `LeaderboardPagination` headless and measured `window.scrollY` on every page change: it holds constant across **all** pages, including the short last one — zero scroll events, zero programmatic scroll calls. `tsc --noEmit` clean.

> Scope: fixed-position is leaderboard-only; the predictions list keeps its inline control (just the scroll removal there).

https://claude.ai/code/session_01JXSopXde4zjbEqfgzMWqrj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXSopXde4zjbEqfgzMWqrj)_