### PR TITLE
Show how played chips affected a user's score

### DIFF
--- a/frontend/app/app/match/[matchId]/predictions/prediction.tsx
+++ b/frontend/app/app/match/[matchId]/predictions/prediction.tsx
@@ -2,17 +2,10 @@
 
 import React from "react";
 import Link from "next/link";
-import {Chip, Match, PredictionWithUser} from "@/client";
+import {Match, PredictionWithUser} from "@/client";
 import {FlagImage} from "@/app/components/predictions/flag-image";
 import {generateHistoryPageLinkForUser} from "@/app/app/user/[userId]/history/user-link-generator";
-import {ChipImpactNote, computeChipImpact} from "@/app/components/predictions/chip-impact";
-
-// Power-up glyphs, mirroring the home-page match pills.
-const CHIP_GLYPH: Partial<Record<Chip, string>> = {
-    [Chip.DoublePoints]: "2×",
-    [Chip.OneGoalOut]: "±1",
-    [Chip.Crowd]: "Crowd",
-}
+import {ChipBadge, chipDisplay, NudgeScore} from "@/app/components/predictions/chip-impact";
 
 export default function PredictionWithLink(props: {
     predictionWithUser: PredictionWithUser
@@ -23,8 +16,7 @@ export default function PredictionWithLink(props: {
     const {user, prediction} = props.predictionWithUser
     const isUser = props.isUser ?? false
     const isPodium = props.position <= 3
-    const chipGlyph = prediction.chip !== Chip.None ? CHIP_GLYPH[prediction.chip] : undefined
-    const chipImpact = computeChipImpact(prediction, props.match)
+    const display = chipDisplay(prediction, props.match)
 
     return (
         <Link className="block max-w-2xl w-full" href={generateHistoryPageLinkForUser(user)}>
@@ -37,8 +29,7 @@ export default function PredictionWithLink(props: {
                             : "bg-slate-900/10 dark:bg-white/10"
                 }`}
             >
-                <div className="rounded-2xl bg-white dark:bg-gray-900/85 backdrop-blur-sm px-4 py-3">
-                    <div className="flex items-center gap-3">
+                <div className="flex items-center gap-3 rounded-2xl bg-white dark:bg-gray-900/85 backdrop-blur-sm px-4 py-3">
                     <div className="flex items-center justify-center w-7 text-lg font-black tabular-nums text-slate-900 dark:text-white">
                         {props.position}
                     </div>
@@ -49,24 +40,19 @@ export default function PredictionWithLink(props: {
                         {user.firstName} {user.familyName}
                     </div>
                     <div className="flex items-center gap-1.5">
-                        {chipGlyph && (
-                            <span className="rounded border border-cyan-500/30 bg-cyan-500/15 px-1.5 py-0.5 text-[9px] font-black leading-none text-cyan-700 dark:border-cyan-400/30 dark:bg-cyan-400/15 dark:text-cyan-300">
-                                {chipGlyph}
+                        {display.predictionBadge && <ChipBadge {...display.predictionBadge}/>}
+                        {display.nudge ? (
+                            <NudgeScore original={display.nudge.original} adjusted={display.nudge.adjusted} className="text-sm font-bold"/>
+                        ) : (
+                            <span className="text-sm font-bold tabular-nums text-slate-500 dark:text-gray-400">
+                                {prediction.homeScore}<span className="px-1 text-slate-300 dark:text-gray-600">-</span>{prediction.awayScore}
                             </span>
                         )}
-                        <span className="text-sm font-bold tabular-nums text-slate-500 dark:text-gray-400">
-                            {prediction.homeScore}<span className="px-1 text-slate-300 dark:text-gray-600">-</span>{prediction.awayScore}
-                        </span>
                     </div>
+                    {display.pointsBadge && <ChipBadge {...display.pointsBadge}/>}
                     {prediction.points !== undefined && (
                         <div className="w-7 text-right text-lg font-black tabular-nums bg-gradient-to-r from-blue-500 via-cyan-500 to-teal-500 dark:from-blue-400 dark:via-cyan-300 dark:to-teal-300 bg-clip-text text-transparent">
                             {prediction.points}
-                        </div>
-                    )}
-                    </div>
-                    {chipImpact && (
-                        <div className="mt-2 pl-[2.875rem]">
-                            <ChipImpactNote impact={chipImpact}/>
                         </div>
                     )}
                 </div>

--- a/frontend/app/app/match/[matchId]/predictions/prediction.tsx
+++ b/frontend/app/app/match/[matchId]/predictions/prediction.tsx
@@ -2,9 +2,10 @@
 
 import React from "react";
 import Link from "next/link";
-import {Chip, PredictionWithUser} from "@/client";
+import {Chip, Match, PredictionWithUser} from "@/client";
 import {FlagImage} from "@/app/components/predictions/flag-image";
 import {generateHistoryPageLinkForUser} from "@/app/app/user/[userId]/history/user-link-generator";
+import {ChipImpactNote, computeChipImpact} from "@/app/components/predictions/chip-impact";
 
 // Power-up glyphs, mirroring the home-page match pills.
 const CHIP_GLYPH: Partial<Record<Chip, string>> = {
@@ -15,6 +16,7 @@ const CHIP_GLYPH: Partial<Record<Chip, string>> = {
 
 export default function PredictionWithLink(props: {
     predictionWithUser: PredictionWithUser
+    match: Match
     position: number
     isUser?: boolean
 }): React.JSX.Element {
@@ -22,6 +24,7 @@ export default function PredictionWithLink(props: {
     const isUser = props.isUser ?? false
     const isPodium = props.position <= 3
     const chipGlyph = prediction.chip !== Chip.None ? CHIP_GLYPH[prediction.chip] : undefined
+    const chipImpact = computeChipImpact(prediction, props.match)
 
     return (
         <Link className="block max-w-2xl w-full" href={generateHistoryPageLinkForUser(user)}>
@@ -34,7 +37,8 @@ export default function PredictionWithLink(props: {
                             : "bg-slate-900/10 dark:bg-white/10"
                 }`}
             >
-                <div className="flex items-center gap-3 rounded-2xl bg-white dark:bg-gray-900/85 backdrop-blur-sm px-4 py-3">
+                <div className="rounded-2xl bg-white dark:bg-gray-900/85 backdrop-blur-sm px-4 py-3">
+                    <div className="flex items-center gap-3">
                     <div className="flex items-center justify-center w-7 text-lg font-black tabular-nums text-slate-900 dark:text-white">
                         {props.position}
                     </div>
@@ -57,6 +61,12 @@ export default function PredictionWithLink(props: {
                     {prediction.points !== undefined && (
                         <div className="w-7 text-right text-lg font-black tabular-nums bg-gradient-to-r from-blue-500 via-cyan-500 to-teal-500 dark:from-blue-400 dark:via-cyan-300 dark:to-teal-300 bg-clip-text text-transparent">
                             {prediction.points}
+                        </div>
+                    )}
+                    </div>
+                    {chipImpact && (
+                        <div className="mt-2 pl-[2.875rem]">
+                            <ChipImpactNote impact={chipImpact}/>
                         </div>
                     )}
                 </div>

--- a/frontend/app/app/match/[matchId]/predictions/predictions.tsx
+++ b/frontend/app/app/match/[matchId]/predictions/predictions.tsx
@@ -165,6 +165,7 @@ export default function Predictions(
                             <PredictionData
                                 key={predictionWithUser.user.userId}
                                 predictionWithUser={predictionWithUser}
+                                match={props.match}
                                 position={currentPage * itemsPerPage + index + 1}
                                 isUser={predictionWithUser.user.userId === props.currentUserId}
                             />

--- a/frontend/app/components/history/history-match-card.tsx
+++ b/frontend/app/components/history/history-match-card.tsx
@@ -1,9 +1,9 @@
 import React from "react"
 import Link from "next/link"
-import {Chip, Match, MatchRoundEnum, MatchStateEnum} from "@/client"
+import {Match, MatchRoundEnum, MatchStateEnum} from "@/client"
 import {FlagImage} from "@/app/components/predictions/flag-image"
 import {LocalTime} from "@/app/components/predictions/local-time"
-import {ChipImpactNote, computeChipImpact} from "@/app/components/predictions/chip-impact"
+import {ChipBadge, chipDisplay, NudgeScore} from "@/app/components/predictions/chip-impact"
 
 const ROUND_LABEL: Record<MatchRoundEnum, string> = {
     GROUP_STAGE: "Group Stage",
@@ -11,13 +11,6 @@ const ROUND_LABEL: Record<MatchRoundEnum, string> = {
     QUARTER_FINAL: "Quarter-Final",
     SEMI_FINAL: "Semi-Final",
     FINAL: "Final",
-}
-
-// Power-ups worth surfacing. Mirrors the glyphs used on the home-page match pills.
-const CHIP_GLYPH: Partial<Record<Chip, string>> = {
-    [Chip.DoublePoints]: "2×",
-    [Chip.OneGoalOut]: "±1",
-    [Chip.Crowd]: "Crowd",
 }
 
 // Points badge colours, consistent with the recent-form dots on the profile.
@@ -31,8 +24,7 @@ export default function HistoryMatchCard({match}: {match: Match}): React.JSX.Ele
     const live = match.state === MatchStateEnum.Live
     const prediction = match.prediction
     const points = prediction?.points
-    const chipGlyph = prediction && prediction.chip !== Chip.None ? CHIP_GLYPH[prediction.chip] : undefined
-    const chipImpact = computeChipImpact(prediction, match)
+    const display = chipDisplay(prediction, match)
 
     return (
         <Link
@@ -81,12 +73,16 @@ export default function HistoryMatchCard({match}: {match: Match}): React.JSX.Ele
                             <>
                                 <span className="text-[9px] font-bold uppercase tracking-[0.15em] text-slate-400 dark:text-gray-500">Prediction</span>
                                 <div className="relative leading-tight">
-                                    <span className="text-base font-bold tabular-nums text-slate-700 dark:text-gray-200">
-                                        {prediction.homeScore}<span className="px-1 text-slate-300 dark:text-gray-600">-</span>{prediction.awayScore}
-                                    </span>
-                                    {chipGlyph && (
-                                        <span className="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 rounded border border-cyan-500/30 bg-cyan-500/15 px-1.5 py-0.5 text-[9px] font-black leading-none text-cyan-700 dark:border-cyan-400/30 dark:bg-cyan-400/15 dark:text-cyan-300">
-                                            {chipGlyph}
+                                    {display.nudge ? (
+                                        <NudgeScore original={display.nudge.original} adjusted={display.nudge.adjusted} className="text-base font-bold"/>
+                                    ) : (
+                                        <span className="text-base font-bold tabular-nums text-slate-700 dark:text-gray-200">
+                                            {prediction.homeScore}<span className="px-1 text-slate-300 dark:text-gray-600">-</span>{prediction.awayScore}
+                                        </span>
+                                    )}
+                                    {display.predictionBadge && (
+                                        <span className="absolute left-full top-1/2 -translate-y-1/2 ml-1.5">
+                                            <ChipBadge {...display.predictionBadge}/>
                                         </span>
                                     )}
                                 </div>
@@ -95,7 +91,8 @@ export default function HistoryMatchCard({match}: {match: Match}): React.JSX.Ele
                             <span className="text-[11px] text-slate-400 dark:text-gray-500">No prediction</span>
                         )}
                     </div>
-                    <div className="flex justify-end">
+                    <div className="flex items-center justify-end gap-1.5">
+                        {display.pointsBadge && <ChipBadge {...display.pointsBadge}/>}
                         {points !== undefined && (
                             <span className={`inline-flex items-center justify-center rounded-full h-6 px-2.5 text-xs font-black tabular-nums ${pointsBadge(points)}`}>
                                 {points} pts
@@ -103,12 +100,6 @@ export default function HistoryMatchCard({match}: {match: Match}): React.JSX.Ele
                         )}
                     </div>
                 </div>
-
-                {chipImpact && (
-                    <div className="mt-2 flex justify-center">
-                        <ChipImpactNote impact={chipImpact}/>
-                    </div>
-                )}
             </div>
         </Link>
     )

--- a/frontend/app/components/history/history-match-card.tsx
+++ b/frontend/app/components/history/history-match-card.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import {Chip, Match, MatchRoundEnum, MatchStateEnum} from "@/client"
 import {FlagImage} from "@/app/components/predictions/flag-image"
 import {LocalTime} from "@/app/components/predictions/local-time"
+import {ChipImpactNote, computeChipImpact} from "@/app/components/predictions/chip-impact"
 
 const ROUND_LABEL: Record<MatchRoundEnum, string> = {
     GROUP_STAGE: "Group Stage",
@@ -31,6 +32,7 @@ export default function HistoryMatchCard({match}: {match: Match}): React.JSX.Ele
     const prediction = match.prediction
     const points = prediction?.points
     const chipGlyph = prediction && prediction.chip !== Chip.None ? CHIP_GLYPH[prediction.chip] : undefined
+    const chipImpact = computeChipImpact(prediction, match)
 
     return (
         <Link
@@ -101,6 +103,12 @@ export default function HistoryMatchCard({match}: {match: Match}): React.JSX.Ele
                         )}
                     </div>
                 </div>
+
+                {chipImpact && (
+                    <div className="mt-2 flex justify-center">
+                        <ChipImpactNote impact={chipImpact}/>
+                    </div>
+                )}
             </div>
         </Link>
     )

--- a/frontend/app/components/predictions/chip-impact.tsx
+++ b/frontend/app/components/predictions/chip-impact.tsx
@@ -4,7 +4,7 @@ import {Chip, Match, Prediction} from "@/client"
 const GLYPH: Partial<Record<Chip, string>> = {
     [Chip.DoublePoints]: "2×",
     [Chip.OneGoalOut]: "±1",
-    [Chip.Crowd]: "Crowd",
+    [Chip.Crowd]: "%",
 }
 
 // Mirrors PointsCalculator.calculateDefaultPoints on the backend
@@ -180,9 +180,13 @@ export function NudgeScore({original, adjusted, className = ""}: {
     className?: string
 }): React.JSX.Element {
     return (
-        <span title={`Off by One nudged ${original.home}–${original.away} to ${adjusted.home}–${adjusted.away}`} className={`tabular-nums ${className}`}>
+        <span title={`Off by One nudged ${original.home}–${original.away} to ${adjusted.home}–${adjusted.away}`} className={`inline-flex items-center tabular-nums ${className}`}>
             <span className="line-through decoration-1 opacity-40">{original.home}–{original.away}</span>
-            <span className="px-1 text-cyan-500 dark:text-cyan-400">→</span>
+            <span className="mx-1 inline-flex items-center text-cyan-500 dark:text-cyan-400" aria-label="off by one">
+                <span className="opacity-60">—</span>
+                <span className="px-0.5 text-[0.7em] font-black leading-none">±1</span>
+                <span className="opacity-60">→</span>
+            </span>
             <span className="text-cyan-600 dark:text-cyan-300">{adjusted.home}–{adjusted.away}</span>
         </span>
     )

--- a/frontend/app/components/predictions/chip-impact.tsx
+++ b/frontend/app/components/predictions/chip-impact.tsx
@@ -1,0 +1,155 @@
+import React from "react"
+import {Chip, Match, Prediction} from "@/client"
+
+// Mirrors PointsCalculator.calculateDefaultPoints on the backend
+// (lambdas/src/main/kotlin/scorcerer/utils/PointsCalculator.kt): 5 for an
+// exact score, 2 for the right outcome, 0 otherwise.
+function defaultPoints(home: number, away: number, resultHome: number, resultAway: number): number {
+    if (home === resultHome && away === resultAway) return 5
+    if (home < away && resultHome < resultAway) return 2
+    if (home > away && resultHome > resultAway) return 2
+    if (home === away && resultHome === resultAway) return 2
+    return 0
+}
+
+export interface ChipImpact {
+    chip: Chip
+    glyph: string
+    label: string
+    // True when the chip earned the user points they would not otherwise have had.
+    helped: boolean
+    // Plain-language explanation, suitable for a tooltip.
+    detail: string
+    // For the ±1 chip: the score the chip nudged the prediction to (when it helped).
+    original?: {home: number; away: number}
+    adjusted?: {home: number; away: number}
+    // Points the chip rescued versus playing the same prediction with no chip.
+    delta?: number
+}
+
+// Reconstructs what a played chip did to a user's score. The backend stores
+// only the original prediction and the final points, not the adjusted score
+// the ±1 chip used, so we recompute it here from the prediction + match result.
+// Returns null when there is nothing to show (no chip, or no result yet).
+export function computeChipImpact(
+    prediction: Prediction | undefined,
+    match: Pick<Match, "homeScore" | "awayScore">,
+): ChipImpact | null {
+    if (!prediction || prediction.chip === Chip.None) return null
+
+    const resultHome = match.homeScore
+    const resultAway = match.awayScore
+    if (resultHome === undefined || resultAway === undefined) return null
+
+    const home = prediction.homeScore
+    const away = prediction.awayScore
+    const base = defaultPoints(home, away, resultHome, resultAway)
+
+    switch (prediction.chip) {
+        case Chip.OneGoalOut: {
+            // Mirrors PointsCalculator.calculatePointsOneGoalOut: the best of four
+            // single-goal adjustments, never scoring below the original prediction.
+            const candidates = [
+                {home: home + 1, away},
+                {home: Math.max(0, home - 1), away},
+                {home, away: away + 1},
+                {home, away: Math.max(0, away - 1)},
+            ]
+            let best = candidates[0]
+            let bestPoints = defaultPoints(best.home, best.away, resultHome, resultAway)
+            for (const candidate of candidates) {
+                const points = defaultPoints(candidate.home, candidate.away, resultHome, resultAway)
+                // Prefer more points; on a tie, prefer the exact result for the clearest story.
+                const isExact = candidate.home === resultHome && candidate.away === resultAway
+                const bestIsExact = best.home === resultHome && best.away === resultAway
+                if (points > bestPoints || (points === bestPoints && isExact && !bestIsExact)) {
+                    best = candidate
+                    bestPoints = points
+                }
+            }
+            if (bestPoints > base) {
+                return {
+                    chip: Chip.OneGoalOut,
+                    glyph: "±1",
+                    label: "Off by One",
+                    helped: true,
+                    original: {home, away},
+                    adjusted: {home: best.home, away: best.away},
+                    delta: bestPoints - base,
+                    detail: `Nudged your ${home}–${away} to ${best.home}–${best.away} for +${bestPoints - base} pts`,
+                }
+            }
+            return {
+                chip: Chip.OneGoalOut,
+                glyph: "±1",
+                label: "Off by One",
+                helped: false,
+                detail: base === 5 ? "Exact score — no nudge needed" : "No nudge could rescue points",
+            }
+        }
+        case Chip.DoublePoints: {
+            if (base > 0) {
+                return {
+                    chip: Chip.DoublePoints,
+                    glyph: "2×",
+                    label: "Double Points",
+                    helped: true,
+                    delta: base,
+                    detail: `Doubled ${base} pts to ${base * 2}`,
+                }
+            }
+            return {
+                chip: Chip.DoublePoints,
+                glyph: "2×",
+                label: "Double Points",
+                helped: false,
+                detail: "No points to double",
+            }
+        }
+        case Chip.Crowd: {
+            // The crowd pick has already been substituted into the stored score
+            // at kickoff (MatchScoring.substituteCrowdPredictions).
+            return {
+                chip: Chip.Crowd,
+                glyph: "Crowd",
+                label: "Follow the Crowd",
+                helped: base > 0,
+                detail: `Locked in the crowd's ${home}–${away}`,
+            }
+        }
+        default:
+            return null
+    }
+}
+
+// Compact pill explaining what a played chip did to the score. For the ±1 chip
+// it shows the original → adjusted nudge; otherwise a short summary line.
+export function ChipImpactNote({impact, className = ""}: {
+    impact: ChipImpact
+    className?: string
+}): React.JSX.Element {
+    const accent = impact.helped
+        ? "border-cyan-500/30 bg-cyan-500/10 text-cyan-700 dark:border-cyan-400/30 dark:bg-cyan-400/10 dark:text-cyan-300"
+        : "border-slate-200 bg-slate-900/[0.03] text-slate-500 dark:border-white/10 dark:bg-white/5 dark:text-gray-400"
+
+    return (
+        <span
+            title={impact.detail}
+            className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold leading-none ${accent} ${className}`}
+        >
+            <span className="font-black tabular-nums">{impact.glyph}</span>
+            {impact.adjusted && impact.original ? (
+                <span className="tabular-nums">
+                    {impact.original.home}–{impact.original.away}
+                    <span className="px-1 opacity-60">→</span>
+                    {impact.adjusted.home}–{impact.adjusted.away}
+                </span>
+            ) : (
+                <span>{impact.detail}</span>
+            )}
+            {impact.delta !== undefined && impact.delta > 0 && (
+                <span className="font-black tabular-nums">+{impact.delta}</span>
+            )}
+        </span>
+    )
+}

--- a/frontend/app/components/predictions/chip-impact.tsx
+++ b/frontend/app/components/predictions/chip-impact.tsx
@@ -1,6 +1,12 @@
 import React from "react"
 import {Chip, Match, Prediction} from "@/client"
 
+const GLYPH: Partial<Record<Chip, string>> = {
+    [Chip.DoublePoints]: "2×",
+    [Chip.OneGoalOut]: "±1",
+    [Chip.Crowd]: "Crowd",
+}
+
 // Mirrors PointsCalculator.calculateDefaultPoints on the backend
 // (lambdas/src/main/kotlin/scorcerer/utils/PointsCalculator.kt): 5 for an
 // exact score, 2 for the right outcome, 0 otherwise.
@@ -15,8 +21,7 @@ function defaultPoints(home: number, away: number, resultHome: number, resultAwa
 export interface ChipImpact {
     chip: Chip
     glyph: string
-    label: string
-    // True when the chip earned the user points they would not otherwise have had.
+    // True when the chip earned points the user would not otherwise have had.
     helped: boolean
     // Plain-language explanation, suitable for a tooltip.
     detail: string
@@ -71,7 +76,6 @@ export function computeChipImpact(
                 return {
                     chip: Chip.OneGoalOut,
                     glyph: "±1",
-                    label: "Off by One",
                     helped: true,
                     original: {home, away},
                     adjusted: {home: best.home, away: best.away},
@@ -82,7 +86,6 @@ export function computeChipImpact(
             return {
                 chip: Chip.OneGoalOut,
                 glyph: "±1",
-                label: "Off by One",
                 helped: false,
                 detail: base === 5 ? "Exact score — no nudge needed" : "No nudge could rescue points",
             }
@@ -92,19 +95,12 @@ export function computeChipImpact(
                 return {
                     chip: Chip.DoublePoints,
                     glyph: "2×",
-                    label: "Double Points",
                     helped: true,
                     delta: base,
                     detail: `Doubled ${base} pts to ${base * 2}`,
                 }
             }
-            return {
-                chip: Chip.DoublePoints,
-                glyph: "2×",
-                label: "Double Points",
-                helped: false,
-                detail: "No points to double",
-            }
+            return {chip: Chip.DoublePoints, glyph: "2×", helped: false, detail: "No points to double"}
         }
         case Chip.Crowd: {
             // The crowd pick has already been substituted into the stored score
@@ -112,7 +108,6 @@ export function computeChipImpact(
             return {
                 chip: Chip.Crowd,
                 glyph: "Crowd",
-                label: "Follow the Crowd",
                 helped: base > 0,
                 detail: `Locked in the crowd's ${home}–${away}`,
             }
@@ -122,34 +117,73 @@ export function computeChipImpact(
     }
 }
 
-// Compact pill explaining what a played chip did to the score. For the ±1 chip
-// it shows the original → adjusted nudge; otherwise a short summary line.
-export function ChipImpactNote({impact, className = ""}: {
-    impact: ChipImpact
+// Where a chip's effect should be surfaced. Effects that change the *prediction*
+// (the ±1 nudge, the crowd lock-in) attach to the prediction; effects that change
+// the *points* (double points) attach to the points.
+export interface ChipDisplay {
+    // ±1 that paid off: render in place of the prediction score (original → adjusted).
+    nudge?: {original: {home: number; away: number}; adjusted: {home: number; away: number}}
+    // Small badge to sit beside the prediction score.
+    predictionBadge?: {glyph: string; muted: boolean; title?: string}
+    // Small badge to sit beside the points.
+    pointsBadge?: {glyph: string; muted: boolean; title?: string}
+}
+
+export function chipDisplay(
+    prediction: Prediction | undefined,
+    match: Pick<Match, "homeScore" | "awayScore">,
+): ChipDisplay {
+    if (!prediction || prediction.chip === Chip.None) return {}
+    const glyph = GLYPH[prediction.chip] ?? ""
+
+    const impact = computeChipImpact(prediction, match)
+    // No result yet — just mark which chip was played, beside the prediction.
+    if (!impact) return {predictionBadge: {glyph, muted: false}}
+
+    switch (prediction.chip) {
+        case Chip.OneGoalOut:
+            if (impact.adjusted && impact.original) {
+                return {nudge: {original: impact.original, adjusted: impact.adjusted}}
+            }
+            return {predictionBadge: {glyph, muted: true, title: impact.detail}}
+        case Chip.Crowd:
+            return {predictionBadge: {glyph, muted: !impact.helped, title: impact.detail}}
+        case Chip.DoublePoints:
+            return {pointsBadge: {glyph, muted: !impact.helped, title: impact.detail}}
+        default:
+            return {}
+    }
+}
+
+// Small bordered chip badge, consistent with the glyph badges used across the app.
+export function ChipBadge({glyph, muted = false, title, className = ""}: {
+    glyph: string
+    muted?: boolean
+    title?: string
     className?: string
 }): React.JSX.Element {
-    const accent = impact.helped
-        ? "border-cyan-500/30 bg-cyan-500/10 text-cyan-700 dark:border-cyan-400/30 dark:bg-cyan-400/10 dark:text-cyan-300"
-        : "border-slate-200 bg-slate-900/[0.03] text-slate-500 dark:border-white/10 dark:bg-white/5 dark:text-gray-400"
-
+    const tone = muted
+        ? "border-slate-200 bg-slate-900/[0.04] text-slate-400 dark:border-white/10 dark:bg-white/5 dark:text-gray-500"
+        : "border-cyan-500/30 bg-cyan-500/15 text-cyan-700 dark:border-cyan-400/30 dark:bg-cyan-400/15 dark:text-cyan-300"
     return (
-        <span
-            title={impact.detail}
-            className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold leading-none ${accent} ${className}`}
-        >
-            <span className="font-black tabular-nums">{impact.glyph}</span>
-            {impact.adjusted && impact.original ? (
-                <span className="tabular-nums">
-                    {impact.original.home}–{impact.original.away}
-                    <span className="px-1 opacity-60">→</span>
-                    {impact.adjusted.home}–{impact.adjusted.away}
-                </span>
-            ) : (
-                <span>{impact.detail}</span>
-            )}
-            {impact.delta !== undefined && impact.delta > 0 && (
-                <span className="font-black tabular-nums">+{impact.delta}</span>
-            )}
+        <span title={title} className={`rounded border px-1.5 py-0.5 text-[9px] font-black leading-none ${tone} ${className}`}>
+            {glyph}
+        </span>
+    )
+}
+
+// Renders a ±1 nudge inline with the prediction: original struck through, the
+// adjusted score highlighted. Sizing/weight is inherited from `className`.
+export function NudgeScore({original, adjusted, className = ""}: {
+    original: {home: number; away: number}
+    adjusted: {home: number; away: number}
+    className?: string
+}): React.JSX.Element {
+    return (
+        <span title={`Off by One nudged ${original.home}–${original.away} to ${adjusted.home}–${adjusted.away}`} className={`tabular-nums ${className}`}>
+            <span className="line-through decoration-1 opacity-40">{original.home}–{original.away}</span>
+            <span className="px-1 text-cyan-500 dark:text-cyan-400">→</span>
+            <span className="text-cyan-600 dark:text-cyan-300">{adjusted.home}–{adjusted.away}</span>
         </span>
     )
 }

--- a/frontend/app/components/predictions/chip-impact.tsx
+++ b/frontend/app/components/predictions/chip-impact.tsx
@@ -182,10 +182,9 @@ export function NudgeScore({original, adjusted, className = ""}: {
     return (
         <span title={`Off by One nudged ${original.home}–${original.away} to ${adjusted.home}–${adjusted.away}`} className={`inline-flex items-center tabular-nums ${className}`}>
             <span className="line-through decoration-1 opacity-40">{original.home}–{original.away}</span>
-            <span className="mx-1 inline-flex items-center text-cyan-500 dark:text-cyan-400" aria-label="off by one">
-                <span className="opacity-60">—</span>
-                <span className="px-0.5 text-[0.7em] font-black leading-none">±1</span>
-                <span className="opacity-60">→</span>
+            <span className="mx-1.5 inline-flex flex-col items-center leading-none text-cyan-500 dark:text-cyan-400" aria-label="off by one">
+                <span className="text-[0.62em] font-black text-cyan-600 dark:text-cyan-300">±1</span>
+                <span className="-mt-px text-[1.1em] leading-none">⟶</span>
             </span>
             <span className="text-cyan-600 dark:text-cyan-300">{adjusted.home}–{adjusted.away}</span>
         </span>


### PR DESCRIPTION
Add a chip-impact note that explains what a played power-up did to a
prediction's points, rather than just marking that a chip was used:

- ±1 (Off by One): shows the original -> adjusted score nudge and the
  points it rescued, reconstructed from the prediction and match result
  (mirrors PointsCalculator.calculatePointsOneGoalOut on the backend).
- Double Points: shows the base points being doubled.
- Crowd: notes the score was locked in from the community pick.

Surfaced on the user's history match cards and the per-match
predictions detail view via a shared computeChipImpact helper and
ChipImpactNote component.