### PR TITLE
Add country rankings leaderboard

### DIFF
--- a/contract/api-contract.yaml
+++ b/contract/api-contract.yaml
@@ -212,6 +212,52 @@ components:
               - IMPROVED
               - WORSENED
               - UNCHANGED
+    countryLeaderboard:
+      description: Ranking of countries against one another. Each country's score is the sum, across every match, of the average points scored by that country's supporters who predicted that match.
+      type: array
+      items:
+        type: object
+        required:
+          - position
+          - movement
+          - teamId
+          - teamName
+          - flagCode
+          - score
+          - predictedMatches
+          - predictorCount
+        properties:
+          position:
+            type: integer
+            format: int32
+            minimum: 1
+          teamId:
+            description: Team Id of the country
+            type: string
+          teamName:
+            description: Country (team) name
+            type: string
+          flagCode:
+            description: Country flag uri
+            type: string
+          score:
+            description: Sum of per-match average points for this country's supporters
+            type: number
+            format: double
+          predictedMatches:
+            description: Number of distinct matches this country's supporters have scored predictions for
+            type: integer
+            format: int32
+          predictorCount:
+            description: Number of supporters of this country who have at least one scored prediction
+            type: integer
+            format: int32
+          movement:
+            type: string
+            enum:
+              - IMPROVED
+              - WORSENED
+              - UNCHANGED
     user:
       type: object
       required:
@@ -1371,6 +1417,31 @@ paths:
       responses:
         '200':
           description: Successful response
+  /leaderboard/countries:
+    get:
+      tags:
+        - league
+      operationId: getCountryRankings
+      description: Returns the leaderboard of countries ranked against one another.
+      security: [ ]
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${apiHandlerArn}/invocations"
+        credentials: "${apiGatewayRoleArn}"
+        payloadFormatVersion: "1.0"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - rankings
+                properties:
+                  rankings:
+                    $ref: '#/components/schemas/countryLeaderboard'
   /tournament/state:
     get:
       tags:

--- a/frontend/app/app/leaderboard/countries/page.tsx
+++ b/frontend/app/app/leaderboard/countries/page.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import Link from "next/link";
+import BackButton from "@/app/components/back-button";
+import {getConfigWithAuthHeader} from "@/app/api/client-config";
+import {CountryLeaderboardInner, LeagueApi} from "@/client";
+import {PitchPerspective} from "@/app/components/atmosphere";
+import CountryRankingEntry from "@/app/components/leaderboard/country-ranking-entry";
+
+function GlobeIcon({className}: {className?: string}): React.JSX.Element {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden>
+            <circle cx="12" cy="12" r="9"/>
+            <path d="M3 12h18"/>
+            <path d="M12 3a14 14 0 0 1 0 18a14 14 0 0 1 0-18Z"/>
+        </svg>
+    )
+}
+
+export default async function CountryRankingsPage(): Promise<React.JSX.Element> {
+    const rankings: CountryLeaderboardInner[] = await new LeagueApi(await getConfigWithAuthHeader())
+        .getCountryRankings()
+        .then(response => response.rankings)
+        .catch(() => [])
+
+    return (
+        <main className="relative min-h-svh bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-x-hidden">
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.08),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.05),transparent_60%)] dark:bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.15),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.10),transparent_60%)]"/>
+            <div className="pointer-events-none absolute inset-x-0 top-0 h-svh"><PitchPerspective/></div>
+
+            <div className="relative w-full max-w-3xl mx-auto px-4 sm:px-6 py-6 space-y-8">
+                <header className="relative flex items-center justify-between gap-3">
+                    <BackButton/>
+                    <Link href="/" className="hidden sm:flex items-baseline font-black tracking-tight text-lg absolute left-1/2 -translate-x-1/2">
+                        <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">predicta</span>
+                        <span className="text-slate-900 dark:text-white">ball</span>
+                        <span className="ml-0.5 text-[10px] font-medium tracking-[0.2em] text-slate-500 dark:text-gray-400">.LIVE</span>
+                    </Link>
+                    <div className="w-10"/>
+                </header>
+
+                <section className="flex flex-col items-center">
+                    <div className="mb-6 flex flex-col items-center text-center">
+                        <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500 via-cyan-400 to-teal-300 shadow-lg shadow-cyan-500/30">
+                            <GlobeIcon className="h-8 w-8 text-white"/>
+                        </div>
+                        <p className="mt-3 text-xs font-bold uppercase tracking-[0.25em] text-slate-500 dark:text-gray-400">Rankings</p>
+                        <h1 className="mt-1 text-3xl font-black tracking-tight text-slate-900 dark:text-white">
+                            Country Rankings
+                        </h1>
+                        <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-gray-400">
+                            Countries ranked against one another. A country&apos;s score for each match is the average points of its supporters who predicted that match.
+                        </p>
+                    </div>
+
+                    <div className="w-full max-w-2xl mx-auto">
+                        {rankings.length === 0 ? (
+                            <div className="rounded-2xl bg-white border border-slate-200 dark:bg-white/5 dark:border-white/10 px-4 py-8 text-center text-sm text-slate-500 dark:text-gray-400">
+                                No country scores yet — check back once matches have been played.
+                            </div>
+                        ) : (
+                            rankings.map(entry => (
+                                <CountryRankingEntry key={entry.teamId} entry={entry}/>
+                            ))
+                        )}
+                    </div>
+                </section>
+            </div>
+        </main>
+    );
+}

--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import Leaderboard from "@/app/components/leaderboard/leaderboard";
 import SignOutButton from "@/app/components/sign-out-button";
 import Dashboard from "@/app/components/leaderboard/dashboard";
+import CountryRankingsPreview from "@/app/components/leaderboard/country-rankings-preview";
+import LeaderboardSkeleton from "@/app/components/leaderboard/leaderboard-skeleton";
 import HeadlineSuspense from "@/app/components/points/headline-suspense";
 import { Toaster } from "react-hot-toast";
 import AdminButton from "@/app/components/admin-button";
@@ -110,7 +112,7 @@ const Home = async ({searchParams}: {searchParams: Promise<Record<string, string
                     </div>
                 </section>
 
-                <section className="space-y-4 pb-10">
+                <section className="space-y-4">
                     <SectionHeading
                         title="Global standing"
                         action={
@@ -122,6 +124,24 @@ const Home = async ({searchParams}: {searchParams: Promise<Record<string, string
                     <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-xl shadow-slate-900/5 dark:shadow-cyan-500/5">
                         <div className="rounded-3xl bg-white/60 dark:bg-white/[0.03] backdrop-blur-sm p-5 sm:p-6">
                             <Leaderboard shouldPaginate={false} leagueId={"global"} limit={true} />
+                        </div>
+                    </div>
+                </section>
+
+                <section className="space-y-4 pb-10">
+                    <SectionHeading
+                        title="Country rankings"
+                        action={
+                            <Link href="/app/leaderboard/countries" className="text-xs font-semibold text-cyan-600 dark:text-cyan-300 hover:text-cyan-700 dark:hover:text-cyan-200 transition-colors">
+                                View all →
+                            </Link>
+                        }
+                    />
+                    <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-xl shadow-slate-900/5 dark:shadow-cyan-500/5">
+                        <div className="rounded-3xl bg-white/60 dark:bg-white/[0.03] backdrop-blur-sm p-5 sm:p-6">
+                            <Suspense fallback={<LeaderboardSkeleton/>}>
+                                <CountryRankingsPreview limit={5}/>
+                            </Suspense>
                         </div>
                     </div>
                 </section>

--- a/frontend/app/components/leaderboard/country-ranking-entry.tsx
+++ b/frontend/app/components/leaderboard/country-ranking-entry.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import {CountryLeaderboardInner} from "@/client"
+import {FlagImage} from "@/app/components/predictions/flag-image"
+
+interface CountryRankingEntryProps {
+    entry: CountryLeaderboardInner
+}
+
+// Show the score with at most two decimals, trimming any trailing zeros so whole
+// numbers read cleanly (e.g. "5" rather than "5.00").
+function formatScore(score: number): string {
+    return Number(score.toFixed(2)).toString()
+}
+
+export default function CountryRankingEntry(props: CountryRankingEntryProps): React.JSX.Element {
+    const {entry} = props
+    const isPodium = entry.position <= 3
+
+    return (
+        <div
+            className={`group relative w-full max-w-2xl rounded-2xl p-[1px] mb-2.5 transition-transform hover:scale-[1.01] ${
+                isPodium
+                    ? "bg-gradient-to-r from-slate-900/20 to-slate-900/10 dark:from-white/25 dark:to-white/10"
+                    : "bg-slate-900/10 dark:bg-white/10"
+            }`}
+        >
+            <div className="flex items-center gap-3 rounded-2xl bg-white dark:bg-gray-900/85 backdrop-blur-sm px-4 py-3">
+                <div className="w-9 text-center text-lg font-black tabular-nums text-slate-900 dark:text-white shrink-0">
+                    {entry.position}
+                </div>
+                <div className="flex w-[26px] justify-center shrink-0">
+                    {entry.flagCode && <FlagImage code={entry.flagCode} name={entry.teamName} size={26}/>}
+                </div>
+                <div className="flex-1 min-w-0 text-left">
+                    <div className="font-semibold text-slate-900 dark:text-white truncate">
+                        {entry.teamName}
+                    </div>
+                    <div className="text-xs text-slate-500 dark:text-gray-400">
+                        {entry.predictorCount} {entry.predictorCount === 1 ? "predictor" : "predictors"} · {entry.predictedMatches} {entry.predictedMatches === 1 ? "match" : "matches"}
+                    </div>
+                </div>
+                <div className="w-16 text-center font-black tabular-nums bg-gradient-to-r from-blue-500 via-cyan-500 to-teal-500 dark:from-blue-400 dark:via-cyan-300 dark:to-teal-300 bg-clip-text text-transparent shrink-0">
+                    {formatScore(entry.score)}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/app/components/leaderboard/country-ranking-entry.tsx
+++ b/frontend/app/components/leaderboard/country-ranking-entry.tsx
@@ -6,10 +6,9 @@ interface CountryRankingEntryProps {
     entry: CountryLeaderboardInner
 }
 
-// Show the score with at most two decimals, trimming any trailing zeros so whole
-// numbers read cleanly (e.g. "5" rather than "5.00").
+// Show the score rounded to a single decimal place (e.g. "5.0").
 function formatScore(score: number): string {
-    return Number(score.toFixed(2)).toString()
+    return score.toFixed(1)
 }
 
 export default function CountryRankingEntry(props: CountryRankingEntryProps): React.JSX.Element {

--- a/frontend/app/components/leaderboard/country-rankings-preview.tsx
+++ b/frontend/app/components/leaderboard/country-rankings-preview.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import {CountryLeaderboardInner, LeagueApi} from "@/client";
+import {getConfigWithAuthHeader} from "@/app/api/client-config";
+import CountryRankingEntry from "@/app/components/leaderboard/country-ranking-entry";
+
+interface CountryRankingsPreviewProps {
+    limit?: number
+}
+
+export default async function CountryRankingsPreview({limit = 5}: CountryRankingsPreviewProps): Promise<React.JSX.Element> {
+    const rankings: CountryLeaderboardInner[] = await new LeagueApi(await getConfigWithAuthHeader())
+        .getCountryRankings()
+        .then(response => response.rankings)
+        .catch(() => [])
+
+    if (rankings.length === 0) {
+        return (
+            <div className="rounded-2xl bg-white border border-slate-200 dark:bg-white/5 dark:border-white/10 px-4 py-6 text-center text-sm text-slate-500 dark:text-gray-400">
+                No country scores yet — check back once matches have been played.
+            </div>
+        )
+    }
+
+    return (
+        <div className="w-full max-w-2xl mx-auto flex flex-col items-center">
+            {rankings.slice(0, limit).map(entry => (
+                <CountryRankingEntry key={entry.teamId} entry={entry}/>
+            ))}
+        </div>
+    )
+}

--- a/lambdas/src/main/kotlin/scorcerer/server/Server.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/Server.kt
@@ -17,6 +17,7 @@ import scorcerer.server.auth.DatabaseAuthProvider
 import scorcerer.server.db.DatabaseFactory
 import scorcerer.server.resources.adminRoutes
 import scorcerer.server.resources.authRoutes
+import scorcerer.server.resources.countryRankingsRoutes
 import scorcerer.server.resources.leagueRoutes
 import scorcerer.server.resources.matchRoutes
 import scorcerer.server.resources.miscRoutes
@@ -53,6 +54,7 @@ private val allRoutes = routes(
     authRoutes(authProvider),
     miscRoutes,
     adminRoutes(leaderboardService, tournamentStateService),
+    countryRankingsRoutes(),
     leagueRoutes(requestContext, leaderboardService),
     matchRoutes(requestContext, leaderboardService, tournamentStateService),
     predictionRoutes(requestContext),

--- a/lambdas/src/main/kotlin/scorcerer/server/Server.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/Server.kt
@@ -54,7 +54,7 @@ private val allRoutes = routes(
     authRoutes(authProvider),
     miscRoutes,
     adminRoutes(leaderboardService, tournamentStateService),
-    countryRankingsRoutes(),
+    countryRankingsRoutes(leaderboardService),
     leagueRoutes(requestContext, leaderboardService),
     matchRoutes(requestContext, leaderboardService, tournamentStateService),
     predictionRoutes(requestContext),

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/CountryRankings.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/CountryRankings.kt
@@ -1,5 +1,6 @@
 package scorcerer.server.resources
 
+import kotlinx.coroutines.runBlocking
 import org.http4k.core.Method
 import org.http4k.core.Response
 import org.http4k.core.Status
@@ -7,10 +8,20 @@ import org.http4k.routing.bind
 import org.http4k.routing.routes
 import org.openapitools.server.models.GetCountryRankings200Response
 import scorcerer.server.toJson
+import scorcerer.utils.LeaderboardService
 import scorcerer.utils.calculateCountryRankings
 
-fun countryRankingsRoutes() = routes(
+fun countryRankingsRoutes(leaderboardService: LeaderboardService) = routes(
     "/leaderboard/countries" bind Method.GET to {
-        Response(Status.OK).body(GetCountryRankings200Response(calculateCountryRankings()).toJson())
+        // Served from the cached snapshot, which is refreshed whenever scores change. The
+        // cold path (empty cache / fresh instance) computes once and writes it back.
+        val rankings = runBlocking {
+            leaderboardService.getCountryRankings() ?: run {
+                val computed = calculateCountryRankings()
+                leaderboardService.writeCountryRankings(computed)
+                computed
+            }
+        }
+        Response(Status.OK).body(GetCountryRankings200Response(rankings).toJson())
     },
 )

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/CountryRankings.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/CountryRankings.kt
@@ -1,0 +1,16 @@
+package scorcerer.server.resources
+
+import org.http4k.core.Method
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.routing.bind
+import org.http4k.routing.routes
+import org.openapitools.server.models.GetCountryRankings200Response
+import scorcerer.server.toJson
+import scorcerer.utils.calculateCountryRankings
+
+fun countryRankingsRoutes() = routes(
+    "/leaderboard/countries" bind Method.GET to {
+        Response(Status.OK).body(GetCountryRankings200Response(calculateCountryRankings()).toJson())
+    },
+)

--- a/lambdas/src/main/kotlin/scorcerer/server/services/MatchScoring.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/services/MatchScoring.kt
@@ -50,6 +50,7 @@ fun endMatch(
 
     runBlocking {
         leaderboardService.updateGlobalLeaderboard(matchDay)
+        leaderboardService.updateCountryRankings()
     }
     tournamentStateService.invalidateCache()
 }
@@ -83,6 +84,7 @@ fun setScore(
 
     runBlocking {
         leaderboardService.updateGlobalLeaderboard(matchDay)
+        leaderboardService.updateCountryRankings()
     }
     tournamentStateService.invalidateCache()
 }

--- a/lambdas/src/main/kotlin/scorcerer/utils/CountryRankings.kt
+++ b/lambdas/src/main/kotlin/scorcerer/utils/CountryRankings.kt
@@ -1,0 +1,103 @@
+package scorcerer.utils
+
+import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.openapitools.server.models.CountryLeaderboardInner
+import scorcerer.server.db.tables.MemberTable
+import scorcerer.server.db.tables.PredictionTable
+import scorcerer.server.db.tables.TeamTable
+
+/**
+ * Rank every country (supported team) against one another.
+ *
+ * A country's score for a single match is the average of the points scored by
+ * that country's supporters who predicted that match — members who did not
+ * predict are ignored. The country's overall score is the sum of those
+ * per-match averages across every match that has been scored.
+ */
+fun calculateCountryRankings(): List<CountryLeaderboardInner> {
+    data class ScoredPrediction(
+        val teamId: Int,
+        val teamName: String,
+        val flagCode: String,
+        val matchId: Int,
+        val memberId: String,
+        val points: Int,
+    )
+
+    val scoredPredictions = transaction {
+        (PredictionTable innerJoin MemberTable)
+            .join(TeamTable, JoinType.INNER, MemberTable.supportedTeamId, TeamTable.id)
+            .select(
+                TeamTable.id,
+                TeamTable.name,
+                TeamTable.flagCode,
+                PredictionTable.matchId,
+                PredictionTable.memberId,
+                PredictionTable.points,
+            )
+            .where { PredictionTable.points.isNotNull() }
+            .map {
+                ScoredPrediction(
+                    it[TeamTable.id],
+                    it[TeamTable.name],
+                    it[TeamTable.flagCode],
+                    it[PredictionTable.matchId],
+                    it[PredictionTable.memberId],
+                    it[PredictionTable.points]!!,
+                )
+            }
+    }
+
+    data class CountryAggregate(
+        val teamId: Int,
+        val teamName: String,
+        val flagCode: String,
+        val score: Double,
+        val predictedMatches: Int,
+        val predictorCount: Int,
+    )
+
+    val aggregates = scoredPredictions
+        .groupBy { it.teamId }
+        .map { (_, predictions) ->
+            val perMatch = predictions.groupBy { it.matchId }
+            val score = perMatch.values.sumOf { matchPredictions ->
+                matchPredictions.map { it.points }.average()
+            }
+            CountryAggregate(
+                teamId = predictions.first().teamId,
+                teamName = predictions.first().teamName.toTitleCase(),
+                flagCode = predictions.first().flagCode,
+                score = score,
+                predictedMatches = perMatch.size,
+                predictorCount = predictions.map { it.memberId }.distinct().size,
+            )
+        }
+
+    val sorted = aggregates.sortedWith(
+        compareByDescending<CountryAggregate> { it.score }.thenBy { it.teamName },
+    )
+
+    var currentPosition = 0
+    var previousScore = Double.MAX_VALUE
+    return sorted.mapIndexed { index, aggregate ->
+        // Standard competition ranking: equal scores share a position.
+        if (aggregate.score < previousScore) {
+            currentPosition = index + 1
+        }
+        previousScore = aggregate.score
+        CountryLeaderboardInner(
+            currentPosition,
+            aggregate.teamId.toString(),
+            aggregate.teamName,
+            aggregate.flagCode,
+            aggregate.score,
+            aggregate.predictedMatches,
+            aggregate.predictorCount,
+            CountryLeaderboardInner.Movement.UNCHANGED,
+        )
+    }
+}

--- a/lambdas/src/main/kotlin/scorcerer/utils/Leaderboard.kt
+++ b/lambdas/src/main/kotlin/scorcerer/utils/Leaderboard.kt
@@ -10,6 +10,7 @@ import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.openapitools.server.models.CountryLeaderboardInner
 import org.openapitools.server.models.LeaderboardInner
 import scorcerer.server.db.tables.LeagueMembershipTable
 import scorcerer.server.db.tables.MemberTable
@@ -112,11 +113,14 @@ class LeaderboardS3Service(val s3Client: S3Client, val s3BucketName: String) : L
     private var cachedLeaderboard: List<LeaderboardInner>? = null
     private var cachedMatchDay: Int? = null
     private var cacheTimestamp: Long = 0
+    private var cachedCountryRankings: List<CountryLeaderboardInner>? = null
+    private var countryRankingsCacheTimestamp: Long = 0
     private val cacheTtlMs = System.getenv("CACHE_TTL_SECONDS")?.toLongOrNull()?.let { it * 1000 } ?: Long.MAX_VALUE
 
     override fun invalidateCache() {
         cachedLeaderboard = null
         cachedMatchDay = null
+        cachedCountryRankings = null
     }
 
     override suspend fun writeLeaderboard(leaderboard: List<LeaderboardInner>, matchDay: Int) {
@@ -186,5 +190,48 @@ class LeaderboardS3Service(val s3Client: S3Client, val s3BucketName: String) : L
         val previousDayLeaderboard = getPreviousLeaderboard(matchDay)
         val updatedGlobalLeaderboard = calculateGlobalLeaderboard(previousDayLeaderboard)
         writeLeaderboard(updatedGlobalLeaderboard, matchDay)
+    }
+
+    override suspend fun writeCountryRankings(rankings: List<CountryLeaderboardInner>) {
+        val request = PutObjectRequest {
+            bucket = s3BucketName
+            key = COUNTRY_RANKINGS_KEY
+            body = ByteStream.fromString(rankings.toJson())
+        }
+        s3Client.putObject(request)
+        cachedCountryRankings = rankings
+        countryRankingsCacheTimestamp = System.currentTimeMillis()
+    }
+
+    override suspend fun getCountryRankings(): List<CountryLeaderboardInner>? {
+        if (cachedCountryRankings != null && System.currentTimeMillis() - countryRankingsCacheTimestamp < cacheTtlMs) {
+            return cachedCountryRankings
+        }
+        val request = GetObjectRequest {
+            bucket = s3BucketName
+            key = COUNTRY_RANKINGS_KEY
+        }
+
+        return try {
+            s3Client.getObject(request) { resp ->
+                val json = resp.body?.decodeToString()
+                requireNotNull(json) { "Country rankings are empty" }
+                val rankings: List<CountryLeaderboardInner> = json.fromJson()
+                cachedCountryRankings = rankings
+                countryRankingsCacheTimestamp = System.currentTimeMillis()
+                return@getObject rankings
+            }
+        } catch (e: Exception) {
+            log.info("Error fetching country rankings: $e")
+            null
+        }
+    }
+
+    override suspend fun updateCountryRankings() {
+        writeCountryRankings(calculateCountryRankings())
+    }
+
+    companion object {
+        private const val COUNTRY_RANKINGS_KEY = "countryRankings.json"
     }
 }

--- a/lambdas/src/main/kotlin/scorcerer/utils/LeaderboardService.kt
+++ b/lambdas/src/main/kotlin/scorcerer/utils/LeaderboardService.kt
@@ -1,5 +1,6 @@
 package scorcerer.utils
 
+import org.openapitools.server.models.CountryLeaderboardInner
 import org.openapitools.server.models.LeaderboardInner
 
 interface LeaderboardService {
@@ -9,4 +10,10 @@ interface LeaderboardService {
     suspend fun getLeaderboard(matchDay: Int): List<LeaderboardInner>?
     suspend fun getPreviousLeaderboard(matchDay: Int): List<LeaderboardInner>?
     suspend fun updateGlobalLeaderboard(matchDay: Int)
+
+    // Country rankings are a single current snapshot (not keyed by match day). They are
+    // recomputed when scores change and served from cache, like the global leaderboard.
+    suspend fun writeCountryRankings(rankings: List<CountryLeaderboardInner>)
+    suspend fun getCountryRankings(): List<CountryLeaderboardInner>?
+    suspend fun updateCountryRankings()
 }

--- a/lambdas/src/main/kotlin/scorcerer/utils/LocalLeaderboardService.kt
+++ b/lambdas/src/main/kotlin/scorcerer/utils/LocalLeaderboardService.kt
@@ -1,10 +1,12 @@
 package scorcerer.utils
 
+import org.openapitools.server.models.CountryLeaderboardInner
 import org.openapitools.server.models.LeaderboardInner
 import scorcerer.server.log
 
 class LocalLeaderboardService : LeaderboardService {
     private val store = mutableMapOf<Int, List<LeaderboardInner>>()
+    private var countryRankings: List<CountryLeaderboardInner>? = null
 
     override fun invalidateCache() {}
 
@@ -28,5 +30,18 @@ class LocalLeaderboardService : LeaderboardService {
     override suspend fun updateGlobalLeaderboard(matchDay: Int) {
         val leaderboard = calculateGlobalLeaderboard(store[matchDay])
         writeLeaderboard(leaderboard, matchDay)
+    }
+
+    override suspend fun writeCountryRankings(rankings: List<CountryLeaderboardInner>) {
+        countryRankings = rankings
+        log.info("Local country rankings written (${rankings.size} entries)")
+    }
+
+    override suspend fun getCountryRankings(): List<CountryLeaderboardInner>? {
+        return countryRankings
+    }
+
+    override suspend fun updateCountryRankings() {
+        writeCountryRankings(calculateCountryRankings())
     }
 }

--- a/lambdas/src/test/kotlin/scorcerer/Utils.kt
+++ b/lambdas/src/test/kotlin/scorcerer/Utils.kt
@@ -13,6 +13,7 @@ fun givenUserExists(
     familyName: String = "Name",
     fixedPoints: Int = 0,
     emailReminders: Boolean = false,
+    supportedTeamId: String? = null,
 ) {
     transaction {
         MemberTable.insert {
@@ -24,6 +25,7 @@ fun givenUserExists(
             it[this.oneOutChips] = 3
             it[this.email] = "$id@test.com"
             it[this.emailReminders] = emailReminders
+            if (supportedTeamId != null) it[this.supportedTeamId] = supportedTeamId.toInt()
         }
     }
 }

--- a/lambdas/src/test/kotlin/scorcerer/integration/MatchLifecycleTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/integration/MatchLifecycleTest.kt
@@ -28,6 +28,7 @@ import scorcerer.utils.livePointsForUser
 class MatchLifecycleTest : PostgresTest() {
     private val leaderboardService = mockk<LeaderboardS3Service> {
         coEvery { updateGlobalLeaderboard(any()) } returns Unit
+        coEvery { updateCountryRankings() } returns Unit
     }
 
     @Test

--- a/lambdas/src/test/kotlin/scorcerer/resources/CountryRankingsTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/resources/CountryRankingsTest.kt
@@ -1,10 +1,12 @@
 package scorcerer.resources
 
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
 import org.http4k.core.Method
 import org.http4k.core.Request
 import org.http4k.core.RequestContexts
 import org.http4k.core.Status
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.openapitools.server.models.GetCountryRankings200Response
 import scorcerer.DatabaseTest
@@ -14,17 +16,29 @@ import scorcerer.givenTeamExists
 import scorcerer.givenUserExists
 import scorcerer.server.fromJson
 import scorcerer.server.resources.countryRankingsRoutes
+import scorcerer.utils.LocalLeaderboardService
 
 class CountryRankingsTest : DatabaseTest() {
     private val contexts = RequestContexts()
-    private val handler = testHandler(contexts, countryRankingsRoutes())
+    private lateinit var leaderboardService: LocalLeaderboardService
+    private lateinit var handler: org.http4k.core.HttpHandler
+
+    @BeforeEach
+    fun setup() {
+        // Fresh service per test so cached snapshots don't leak between tests.
+        leaderboardService = LocalLeaderboardService()
+        handler = testHandler(contexts, countryRankingsRoutes(leaderboardService))
+    }
+
+    private fun getRankings(): GetCountryRankings200Response {
+        val response = handler(Request(Method.GET, "/leaderboard/countries"))
+        response.status shouldBe Status.OK
+        return response.bodyString().fromJson()
+    }
 
     @Test
     fun emptyWhenNoScoredPredictions() {
-        val response = handler(Request(Method.GET, "/leaderboard/countries"))
-        response.status shouldBe Status.OK
-        val body: GetCountryRankings200Response = response.bodyString().fromJson()
-        body.rankings.size shouldBe 0
+        getRankings().rankings.size shouldBe 0
     }
 
     @Test
@@ -48,20 +62,17 @@ class CountryRankingsTest : DatabaseTest() {
         givenUserExists("fra-1", "Fra", supportedTeamId = france)
         givenPredictionExists(match, "fra-1", 1, 0, points = 3)
 
-        val response = handler(Request(Method.GET, "/leaderboard/countries"))
-        response.status shouldBe Status.OK
-        val body: GetCountryRankings200Response = response.bodyString().fromJson()
+        val rankings = getRankings().rankings
+        rankings.size shouldBe 2
 
-        body.rankings.size shouldBe 2
-
-        val first = body.rankings[0]
+        val first = rankings[0]
         first.position shouldBe 1
         first.teamName shouldBe "England"
         first.score shouldBe 5.0
         first.predictedMatches shouldBe 1
         first.predictorCount shouldBe 2
 
-        val second = body.rankings[1]
+        val second = rankings[1]
         second.position shouldBe 2
         second.teamName shouldBe "France"
         second.score shouldBe 3.0
@@ -84,12 +95,33 @@ class CountryRankingsTest : DatabaseTest() {
         givenPredictionExists(matchOne, "eng-2", 1, 0, points = 1)
         givenPredictionExists(matchTwo, "eng-1", 1, 0, points = 4)
 
-        val response = handler(Request(Method.GET, "/leaderboard/countries"))
-        response.status shouldBe Status.OK
-        val body: GetCountryRankings200Response = response.bodyString().fromJson()
+        val rankings = getRankings().rankings
+        rankings.size shouldBe 1
+        rankings[0].score shouldBe 7.0
+        rankings[0].predictedMatches shouldBe 2
+    }
 
-        body.rankings.size shouldBe 1
-        body.rankings[0].score shouldBe 7.0
-        body.rankings[0].predictedMatches shouldBe 2
+    @Test
+    fun servesCachedSnapshotWithoutRecomputing() {
+        val england = givenTeamExists("england")
+        val homeTeam = givenTeamExists("brazil")
+        val awayTeam = givenTeamExists("spain")
+        val match = givenMatchExists(homeTeam, awayTeam)
+
+        givenUserExists("eng-1", "Eng", supportedTeamId = england)
+        givenPredictionExists(match, "eng-1", 1, 0, points = 4)
+
+        // First request populates the cache.
+        getRankings().rankings.single().score shouldBe 4.0
+
+        // Underlying data changes, but without a score-update trigger the cached
+        // snapshot is served unchanged (i.e. we are not recomputing per request).
+        givenUserExists("eng-2", "Eng", supportedTeamId = england)
+        givenPredictionExists(match, "eng-2", 1, 0, points = 8)
+        getRankings().rankings.single().score shouldBe 4.0
+
+        // Refreshing the snapshot (as a score update would) picks up the new data.
+        runBlocking { leaderboardService.updateCountryRankings() }
+        getRankings().rankings.single().score shouldBe 6.0
     }
 }

--- a/lambdas/src/test/kotlin/scorcerer/resources/CountryRankingsTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/resources/CountryRankingsTest.kt
@@ -1,0 +1,95 @@
+package scorcerer.resources
+
+import io.kotest.matchers.shouldBe
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.RequestContexts
+import org.http4k.core.Status
+import org.junit.jupiter.api.Test
+import org.openapitools.server.models.GetCountryRankings200Response
+import scorcerer.DatabaseTest
+import scorcerer.givenMatchExists
+import scorcerer.givenPredictionExists
+import scorcerer.givenTeamExists
+import scorcerer.givenUserExists
+import scorcerer.server.fromJson
+import scorcerer.server.resources.countryRankingsRoutes
+
+class CountryRankingsTest : DatabaseTest() {
+    private val contexts = RequestContexts()
+    private val handler = testHandler(contexts, countryRankingsRoutes())
+
+    @Test
+    fun emptyWhenNoScoredPredictions() {
+        val response = handler(Request(Method.GET, "/leaderboard/countries"))
+        response.status shouldBe Status.OK
+        val body: GetCountryRankings200Response = response.bodyString().fromJson()
+        body.rankings.size shouldBe 0
+    }
+
+    @Test
+    fun ranksCountriesByAverageOfSupporterPoints() {
+        val england = givenTeamExists("england")
+        val france = givenTeamExists("france")
+        val homeTeam = givenTeamExists("brazil")
+        val awayTeam = givenTeamExists("spain")
+
+        val match = givenMatchExists(homeTeam, awayTeam)
+
+        // England has two supporters who predicted (8 and 2 -> avg 5).
+        givenUserExists("eng-1", "Eng", supportedTeamId = england)
+        givenUserExists("eng-2", "Eng", supportedTeamId = england)
+        // England supporter who did NOT predict: must be ignored.
+        givenUserExists("eng-3", "Eng", supportedTeamId = england)
+        givenPredictionExists(match, "eng-1", 1, 0, points = 8)
+        givenPredictionExists(match, "eng-2", 1, 0, points = 2)
+
+        // France has one supporter who predicted (3 -> avg 3).
+        givenUserExists("fra-1", "Fra", supportedTeamId = france)
+        givenPredictionExists(match, "fra-1", 1, 0, points = 3)
+
+        val response = handler(Request(Method.GET, "/leaderboard/countries"))
+        response.status shouldBe Status.OK
+        val body: GetCountryRankings200Response = response.bodyString().fromJson()
+
+        body.rankings.size shouldBe 2
+
+        val first = body.rankings[0]
+        first.position shouldBe 1
+        first.teamName shouldBe "England"
+        first.score shouldBe 5.0
+        first.predictedMatches shouldBe 1
+        first.predictorCount shouldBe 2
+
+        val second = body.rankings[1]
+        second.position shouldBe 2
+        second.teamName shouldBe "France"
+        second.score shouldBe 3.0
+        second.predictorCount shouldBe 1
+    }
+
+    @Test
+    fun sumsPerMatchAveragesAcrossMatches() {
+        val england = givenTeamExists("england")
+        val homeTeam = givenTeamExists("brazil")
+        val awayTeam = givenTeamExists("spain")
+
+        val matchOne = givenMatchExists(homeTeam, awayTeam)
+        val matchTwo = givenMatchExists(homeTeam, awayTeam)
+
+        givenUserExists("eng-1", "Eng", supportedTeamId = england)
+        givenUserExists("eng-2", "Eng", supportedTeamId = england)
+        // Match one: avg of 5 and 1 = 3. Match two: only one predictor = 4.
+        givenPredictionExists(matchOne, "eng-1", 1, 0, points = 5)
+        givenPredictionExists(matchOne, "eng-2", 1, 0, points = 1)
+        givenPredictionExists(matchTwo, "eng-1", 1, 0, points = 4)
+
+        val response = handler(Request(Method.GET, "/leaderboard/countries"))
+        response.status shouldBe Status.OK
+        val body: GetCountryRankings200Response = response.bodyString().fromJson()
+
+        body.rankings.size shouldBe 1
+        body.rankings[0].score shouldBe 7.0
+        body.rankings[0].predictedMatches shouldBe 2
+    }
+}

--- a/lambdas/src/test/kotlin/scorcerer/resources/MatchTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/resources/MatchTest.kt
@@ -179,7 +179,9 @@ class MatchTest : DatabaseTest() {
         getPredictionPoints(predictionId) shouldBe 5
         coVerifySequence {
             mockLeaderboardService.updateGlobalLeaderboard(5)
+            mockLeaderboardService.updateCountryRankings()
             mockLeaderboardService.updateGlobalLeaderboard(5)
+            mockLeaderboardService.updateCountryRankings()
         }
     }
 


### PR DESCRIPTION
## What

Adds a **Country Rankings** leaderboard where every country is ranked against one another.

A country's score for a single match is the **average of the points scored by that country's supporters who predicted that match** — members who didn't predict are ignored. The country's overall score is the **sum of those per-match averages** across every scored match. Countries are sorted by total score (ties share a position).

"Country" here means a member's supported team (`member.supported_team_id`), the same notion the existing per-country leagues already use.

## How

**Contract** (`contract/api-contract.yaml`)
- New `countryLeaderboard` schema (position, teamId, teamName, flagCode, score, predictedMatches, predictorCount, movement).
- New `GET /leaderboard/countries` endpoint returning `{ rankings }`.

**Backend** (`lambdas`)
- `calculateCountryRankings()` aggregates scored predictions by supported team → per-match average → summed score, with predictor/match counts.
- `countryRankingsRoutes()` exposes the endpoint, wired into `Server.kt`.
- `givenUserExists` test helper gains an optional `supportedTeamId`.
- New `CountryRankingsTest` covering empty state, per-match averaging (ignoring non-predictors), and summing across matches.

**Frontend** (`frontend`)
- `CountryRankingEntry` row component and a full `/app/leaderboard/countries` page.
- A new **Country rankings** section on the home page (separate from the leagues dashboard) showing the top 5 with a "View all →" link.

## Notes
- `movement` is included in the schema for parity with the user leaderboard but is currently always `UNCHANGED` — there's no per-country snapshot history yet (the existing movement infra is S3 match-day snapshots of the user leaderboard). Left as a future enhancement.
- Score uses scored prediction `points`, so it naturally includes live-match points while a match is in progress and settles to final points once completed.

## Testing
- `./gradlew ktlintCheck` and unit tests pass (`CountryRankingsTest` + existing resource/util suites).
- Frontend `tsc --noEmit` and `next lint` clean (only a pre-existing unrelated warning).

https://claude.ai/code/session_019EFFETKYgKbEmF9r28hc93

---
_Generated by [Claude Code](https://claude.ai/code/session_019EFFETKYgKbEmF9r28hc93)_