### PR TITLE
Reduce global leaderboard preview to leader + 2 around user

### DIFF
--- a/frontend/app/components/leaderboard/entries.tsx
+++ b/frontend/app/components/leaderboard/entries.tsx
@@ -51,7 +51,7 @@ export default async function Entries(props: EntriesProps): Promise<React.JSX.El
         const elementsForLeaderboard = filterWithContext(
             wholeLeaderboard,
             (element) => element.user.userId === userId,
-            4
+            2
         )
         return elementsForLeaderboard.find(x => x === leader) !== undefined
             ? elementsForLeaderboard


### PR DESCRIPTION
Narrow the limited global standing on the main app page from 4 entries
above/below the user to 2, keeping 1st place plus the user with two
neighbours on each side.