### PR TITLE
Link country ranking entries to their country leagues

### DIFF
--- a/contract/api-contract.yaml
+++ b/contract/api-contract.yaml
@@ -222,6 +222,7 @@ components:
           - movement
           - teamId
           - teamName
+          - leagueId
           - flagCode
           - score
           - predictedMatches
@@ -236,6 +237,9 @@ components:
             type: string
           teamName:
             description: Country (team) name
+            type: string
+          leagueId:
+            description: Id of this country's league
             type: string
           flagCode:
             description: Country flag uri

--- a/frontend/app/components/leaderboard/country-ranking-entry.tsx
+++ b/frontend/app/components/leaderboard/country-ranking-entry.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import Link from "next/link"
 import {CountryLeaderboardInner} from "@/client"
 import {FlagImage} from "@/app/components/predictions/flag-image"
-import {countryLeagueId} from "@/app/util/leagues"
 
 interface CountryRankingEntryProps {
     entry: CountryLeaderboardInner
@@ -19,7 +18,7 @@ export default function CountryRankingEntry(props: CountryRankingEntryProps): Re
 
     return (
         <Link
-            href={`/league/${countryLeagueId(entry.teamName)}/leaderboard`}
+            href={`/league/${entry.leagueId}/leaderboard`}
             className={`group relative block w-full max-w-2xl rounded-2xl p-[1px] mb-2.5 transition-transform hover:scale-[1.01] ${
                 isPodium
                     ? "bg-gradient-to-r from-slate-900/20 to-slate-900/10 dark:from-white/25 dark:to-white/10"

--- a/frontend/app/components/leaderboard/country-ranking-entry.tsx
+++ b/frontend/app/components/leaderboard/country-ranking-entry.tsx
@@ -1,6 +1,8 @@
 import React from "react"
+import Link from "next/link"
 import {CountryLeaderboardInner} from "@/client"
 import {FlagImage} from "@/app/components/predictions/flag-image"
+import {countryLeagueId} from "@/app/util/leagues"
 
 interface CountryRankingEntryProps {
     entry: CountryLeaderboardInner
@@ -16,8 +18,9 @@ export default function CountryRankingEntry(props: CountryRankingEntryProps): Re
     const isPodium = entry.position <= 3
 
     return (
-        <div
-            className={`group relative w-full max-w-2xl rounded-2xl p-[1px] mb-2.5 transition-transform hover:scale-[1.01] ${
+        <Link
+            href={`/league/${countryLeagueId(entry.teamName)}/leaderboard`}
+            className={`group relative block w-full max-w-2xl rounded-2xl p-[1px] mb-2.5 transition-transform hover:scale-[1.01] ${
                 isPodium
                     ? "bg-gradient-to-r from-slate-900/20 to-slate-900/10 dark:from-white/25 dark:to-white/10"
                     : "bg-slate-900/10 dark:bg-white/10"
@@ -42,6 +45,6 @@ export default function CountryRankingEntry(props: CountryRankingEntryProps): Re
                     {formatScore(entry.score)}
                 </div>
             </div>
-        </div>
+        </Link>
     )
 }

--- a/frontend/app/util/leagues.ts
+++ b/frontend/app/util/leagues.ts
@@ -11,3 +11,10 @@ export function isManagedLeague(kind: LeagueKindEnum): boolean {
 export function inviteUrl(leagueId: string): string {
     return `https://www.predictaball.live/league/${leagueId}/join`
 }
+
+// The country league ID is the slugified team name (e.g. "South Africa" ->
+// "south-africa"), matching how the backend derives it when auto-creating the
+// per-country leagues. Used to link a country ranking entry to its league.
+export function countryLeagueId(teamName: string): string {
+    return teamName.toLowerCase().replace(/\s+/g, "-")
+}

--- a/frontend/app/util/leagues.ts
+++ b/frontend/app/util/leagues.ts
@@ -11,10 +11,3 @@ export function isManagedLeague(kind: LeagueKindEnum): boolean {
 export function inviteUrl(leagueId: string): string {
     return `https://www.predictaball.live/league/${leagueId}/join`
 }
-
-// The country league ID is the slugified team name (e.g. "South Africa" ->
-// "south-africa"), matching how the backend derives it when auto-creating the
-// per-country leagues. Used to link a country ranking entry to its league.
-export function countryLeagueId(teamName: string): string {
-    return teamName.toLowerCase().replace(/\s+/g, "-")
-}

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/User.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/User.kt
@@ -43,6 +43,7 @@ import scorcerer.utils.LeaderboardService
 import scorcerer.utils.capitaliseName
 import scorcerer.utils.filterLeaderboardToLeague
 import scorcerer.utils.livePointsForUser
+import scorcerer.utils.toCountryLeagueId
 import scorcerer.utils.toTitleCase
 import scorcerer.utils.toUser
 
@@ -79,7 +80,7 @@ private fun addToCountryLeague(userId: String, teamId: Int) {
         transaction {
             val rawTeamName = TeamTable.select(TeamTable.name).where { TeamTable.id eq teamId }
                 .single()[TeamTable.name]
-            val leagueId = rawTeamName.lowercase().replace(Regex("\\s+"), "-")
+            val leagueId = rawTeamName.toCountryLeagueId()
             val leagueName = rawTeamName.toTitleCase()
             val leagueExists = LeagueTable.selectAll().where { LeagueTable.id eq leagueId }.count() > 0
             if (!leagueExists) {
@@ -324,7 +325,7 @@ fun userRoutes(contexts: RequestContexts, leaderboardService: LeaderboardService
             // When the team changes, swap the country-league membership.
             if (newTeamId != null && previousTeamId != null && previousTeamId != newTeamId) {
                 val previousLeagueId = TeamTable.select(TeamTable.name).where { TeamTable.id eq previousTeamId }
-                    .single()[TeamTable.name].lowercase().replace(Regex("\\s+"), "-")
+                    .single()[TeamTable.name].toCountryLeagueId()
                 LeagueMembershipTable.deleteWhere {
                     (LeagueMembershipTable.memberId eq userId).and(LeagueMembershipTable.leagueId eq previousLeagueId)
                 }

--- a/lambdas/src/main/kotlin/scorcerer/utils/CountryRankings.kt
+++ b/lambdas/src/main/kotlin/scorcerer/utils/CountryRankings.kt
@@ -54,6 +54,7 @@ fun calculateCountryRankings(): List<CountryLeaderboardInner> {
     data class CountryAggregate(
         val teamId: Int,
         val teamName: String,
+        val leagueId: String,
         val flagCode: String,
         val score: Double,
         val predictedMatches: Int,
@@ -67,9 +68,11 @@ fun calculateCountryRankings(): List<CountryLeaderboardInner> {
             val score = perMatch.values.sumOf { matchPredictions ->
                 matchPredictions.map { it.points }.average()
             }
+            val rawTeamName = predictions.first().teamName
             CountryAggregate(
                 teamId = predictions.first().teamId,
-                teamName = predictions.first().teamName.toTitleCase(),
+                teamName = rawTeamName.toTitleCase(),
+                leagueId = rawTeamName.toCountryLeagueId(),
                 flagCode = predictions.first().flagCode,
                 score = score,
                 predictedMatches = perMatch.size,
@@ -90,14 +93,15 @@ fun calculateCountryRankings(): List<CountryLeaderboardInner> {
         }
         previousScore = aggregate.score
         CountryLeaderboardInner(
-            currentPosition,
-            aggregate.teamId.toString(),
-            aggregate.teamName,
-            aggregate.flagCode,
-            aggregate.score,
-            aggregate.predictedMatches,
-            aggregate.predictorCount,
-            CountryLeaderboardInner.Movement.UNCHANGED,
+            position = currentPosition,
+            teamId = aggregate.teamId.toString(),
+            teamName = aggregate.teamName,
+            leagueId = aggregate.leagueId,
+            flagCode = aggregate.flagCode,
+            score = aggregate.score,
+            predictedMatches = aggregate.predictedMatches,
+            predictorCount = aggregate.predictorCount,
+            movement = CountryLeaderboardInner.Movement.UNCHANGED,
         )
     }
 }

--- a/lambdas/src/main/kotlin/scorcerer/utils/StringUtils.kt
+++ b/lambdas/src/main/kotlin/scorcerer/utils/StringUtils.kt
@@ -17,3 +17,12 @@ fun String.capitaliseName(): String {
         word.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
     }
 }
+
+/**
+ * The country-league ID for a team name: the slugified name (e.g. "South Africa"
+ * -> "south-africa"). This is the canonical place this rule lives — country
+ * leagues are auto-created with this ID, and the rankings reference them by it.
+ */
+fun String.toCountryLeagueId(): String {
+    return this.lowercase().replace(Regex("\\s+"), "-")
+}

--- a/lambdas/src/test/kotlin/scorcerer/resources/CountryRankingsTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/resources/CountryRankingsTest.kt
@@ -68,6 +68,7 @@ class CountryRankingsTest : DatabaseTest() {
         val first = rankings[0]
         first.position shouldBe 1
         first.teamName shouldBe "England"
+        first.leagueId shouldBe "england"
         first.score shouldBe 5.0
         first.predictedMatches shouldBe 1
         first.predictorCount shouldBe 2
@@ -75,6 +76,7 @@ class CountryRankingsTest : DatabaseTest() {
         val second = rankings[1]
         second.position shouldBe 2
         second.teamName shouldBe "France"
+        second.leagueId shouldBe "france"
         second.score shouldBe 3.0
         second.predictorCount shouldBe 1
     }


### PR DESCRIPTION
Each country in the country rankings now links through to that country's
league leaderboard. The league ID is derived from the team name using the
same slug rule the backend uses when auto-creating per-country leagues.