### PR TITLE
Fix country ranking links to use the app/league route

### DIFF
--- a/frontend/app/components/leaderboard/country-ranking-entry.tsx
+++ b/frontend/app/components/leaderboard/country-ranking-entry.tsx
@@ -18,7 +18,7 @@ export default function CountryRankingEntry(props: CountryRankingEntryProps): Re
 
     return (
         <Link
-            href={`/league/${entry.leagueId}/leaderboard`}
+            href={`app/league/${entry.leagueId}/leaderboard`}
             className={`group relative block w-full max-w-2xl rounded-2xl p-[1px] mb-2.5 transition-transform hover:scale-[1.01] ${
                 isPodium
                     ? "bg-gradient-to-r from-slate-900/20 to-slate-900/10 dark:from-white/25 dark:to-white/10"


### PR DESCRIPTION
The country ranking entries linked to `/league/{id}/leaderboard`, which doesn't match the app's routing. They now use `app/league/{id}/leaderboard`, consistent with the rest of the league links (e.g. `LeagueComponent`).

https://claude.ai/code/session_016A3ET78TQ94hu6ws95fHg9

---
_Generated by [Claude Code](https://claude.ai/code/session_016A3ET78TQ94hu6ws95fHg9)_