### PR TITLE
Include all represented countries in country rankings

### DIFF
--- a/lambdas/src/main/kotlin/scorcerer/utils/CountryRankings.kt
+++ b/lambdas/src/main/kotlin/scorcerer/utils/CountryRankings.kt
@@ -12,6 +12,10 @@ import scorcerer.server.db.tables.TeamTable
 /**
  * Rank every country (supported team) against one another.
  *
+ * Every country represented in the game — i.e. supported by at least one
+ * member — is included, even if none of its supporters have a scored
+ * prediction yet (such countries score 0.0).
+ *
  * A country's score for a single match is the average of the points scored by
  * that country's supporters who predicted that match — members who did not
  * predict are ignored. The country's overall score is the sum of those
@@ -20,20 +24,35 @@ import scorcerer.server.db.tables.TeamTable
 fun calculateCountryRankings(): List<CountryLeaderboardInner> {
     data class ScoredPrediction(
         val teamId: Int,
-        val teamName: String,
-        val flagCode: String,
         val matchId: Int,
         val memberId: String,
         val points: Int,
     )
 
-    val scoredPredictions = transaction {
-        (PredictionTable innerJoin MemberTable)
+    data class RepresentedCountry(
+        val teamId: Int,
+        val teamName: String,
+        val flagCode: String,
+    )
+
+    val (representedCountries, scoredPredictions) = transaction {
+        // Every country with at least one supporter is represented in the game.
+        val countries = MemberTable
+            .join(TeamTable, JoinType.INNER, MemberTable.supportedTeamId, TeamTable.id)
+            .select(TeamTable.id, TeamTable.name, TeamTable.flagCode)
+            .map {
+                RepresentedCountry(
+                    it[TeamTable.id],
+                    it[TeamTable.name],
+                    it[TeamTable.flagCode],
+                )
+            }
+            .distinctBy { it.teamId }
+
+        val predictions = (PredictionTable innerJoin MemberTable)
             .join(TeamTable, JoinType.INNER, MemberTable.supportedTeamId, TeamTable.id)
             .select(
                 TeamTable.id,
-                TeamTable.name,
-                TeamTable.flagCode,
                 PredictionTable.matchId,
                 PredictionTable.memberId,
                 PredictionTable.points,
@@ -42,13 +61,13 @@ fun calculateCountryRankings(): List<CountryLeaderboardInner> {
             .map {
                 ScoredPrediction(
                     it[TeamTable.id],
-                    it[TeamTable.name],
-                    it[TeamTable.flagCode],
                     it[PredictionTable.matchId],
                     it[PredictionTable.memberId],
                     it[PredictionTable.points]!!,
                 )
             }
+
+        countries to predictions
     }
 
     data class CountryAggregate(
@@ -61,19 +80,21 @@ fun calculateCountryRankings(): List<CountryLeaderboardInner> {
         val predictorCount: Int,
     )
 
-    val aggregates = scoredPredictions
-        .groupBy { it.teamId }
-        .map { (_, predictions) ->
+    val predictionsByTeam = scoredPredictions.groupBy { it.teamId }
+
+    val aggregates = representedCountries
+        .map { country ->
+            val predictions = predictionsByTeam[country.teamId].orEmpty()
             val perMatch = predictions.groupBy { it.matchId }
+            // Countries whose supporters haven't scored a prediction yet score 0.0.
             val score = perMatch.values.sumOf { matchPredictions ->
                 matchPredictions.map { it.points }.average()
             }
-            val rawTeamName = predictions.first().teamName
             CountryAggregate(
-                teamId = predictions.first().teamId,
-                teamName = rawTeamName.toTitleCase(),
-                leagueId = rawTeamName.toCountryLeagueId(),
-                flagCode = predictions.first().flagCode,
+                teamId = country.teamId,
+                teamName = country.teamName.toTitleCase(),
+                leagueId = country.teamName.toCountryLeagueId(),
+                flagCode = country.flagCode,
                 score = score,
                 predictedMatches = perMatch.size,
                 predictorCount = predictions.map { it.memberId }.distinct().size,

--- a/lambdas/src/test/kotlin/scorcerer/resources/CountryRankingsTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/resources/CountryRankingsTest.kt
@@ -37,8 +37,60 @@ class CountryRankingsTest : DatabaseTest() {
     }
 
     @Test
-    fun emptyWhenNoScoredPredictions() {
+    fun emptyWhenNoCountriesRepresented() {
         getRankings().rankings.size shouldBe 0
+    }
+
+    @Test
+    fun includesRepresentedCountriesWithoutScoredPredictions() {
+        val england = givenTeamExists("england")
+        val france = givenTeamExists("france")
+        val homeTeam = givenTeamExists("brazil")
+        val awayTeam = givenTeamExists("spain")
+
+        val match = givenMatchExists(homeTeam, awayTeam)
+
+        // England has a supporter who scored a prediction.
+        givenUserExists("eng-1", "Eng", supportedTeamId = england)
+        givenPredictionExists(match, "eng-1", 1, 0, points = 6)
+
+        // France is represented (has a supporter) but no scored predictions yet.
+        givenUserExists("fra-1", "Fra", supportedTeamId = france)
+
+        val rankings = getRankings().rankings
+        rankings.size shouldBe 2
+
+        val first = rankings[0]
+        first.position shouldBe 1
+        first.teamName shouldBe "England"
+        first.score shouldBe 6.0
+        first.predictedMatches shouldBe 1
+        first.predictorCount shouldBe 1
+
+        val second = rankings[1]
+        second.position shouldBe 2
+        second.teamName shouldBe "France"
+        second.leagueId shouldBe "france"
+        second.score shouldBe 0.0
+        second.predictedMatches shouldBe 0
+        second.predictorCount shouldBe 0
+    }
+
+    @Test
+    fun unsupportedTeamsAreNotRepresented() {
+        // brazil and spain only appear as match participants — nobody supports
+        // them — so they must not show up in the country rankings.
+        val england = givenTeamExists("england")
+        val homeTeam = givenTeamExists("brazil")
+        val awayTeam = givenTeamExists("spain")
+        val match = givenMatchExists(homeTeam, awayTeam)
+
+        givenUserExists("eng-1", "Eng", supportedTeamId = england)
+        givenPredictionExists(match, "eng-1", 1, 0, points = 4)
+
+        val rankings = getRankings().rankings
+        rankings.size shouldBe 1
+        rankings.single().teamName shouldBe "England"
     }
 
     @Test


### PR DESCRIPTION
Country rankings now list every country represented in the game (i.e.
supported by at least one member), even when none of its supporters have
a scored prediction yet. Such countries score 0.0 rather than being
omitted entirely.