### PR TITLE
Place form graphic in line with rank and points on mobile

### DIFF
--- a/frontend/app/app/user/[userId]/history/page.tsx
+++ b/frontend/app/app/user/[userId]/history/page.tsx
@@ -108,7 +108,8 @@ export default async function Home({
 
                                     {/* On mobile the form sits in line with rank & points; on desktop it moves to its own block below */}
                                     {form.length > 0 && (
-                                        <div className="flex items-center sm:hidden">
+                                        <div className="flex flex-col items-center justify-center gap-1.5 sm:hidden">
+                                            <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400">Recent form</p>
                                             <FormBadge form={form}/>
                                         </div>
                                     )}

--- a/frontend/app/app/user/[userId]/history/page.tsx
+++ b/frontend/app/app/user/[userId]/history/page.tsx
@@ -91,21 +91,32 @@ export default async function Home({
 
                     {(leaderboardEntry || form.length > 0) && (
                         <div className="flex flex-col items-start sm:items-end gap-4 shrink-0">
-                            {leaderboardEntry && (
+                            {(leaderboardEntry || form.length > 0) && (
                                 <div className="flex items-stretch gap-3">
-                                    <div className="rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/70 dark:bg-gray-900/70 backdrop-blur-sm px-5 py-2.5 min-w-[88px] text-center">
-                                        <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400">Rank</p>
-                                        <p className="text-xl font-black tabular-nums text-slate-900 dark:text-white">#{leaderboardEntry.position}</p>
-                                    </div>
-                                    <div className="rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/70 dark:bg-gray-900/70 backdrop-blur-sm px-5 py-2.5 min-w-[88px] text-center">
-                                        <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400">Points</p>
-                                        <p className="text-xl font-black tabular-nums bg-gradient-to-r from-blue-500 via-cyan-500 to-teal-500 dark:from-blue-400 dark:via-cyan-300 dark:to-teal-300 bg-clip-text text-transparent">{totalPoints}</p>
-                                    </div>
+                                    {leaderboardEntry && (
+                                        <div className="rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/70 dark:bg-gray-900/70 backdrop-blur-sm px-5 py-2.5 min-w-[88px] text-center">
+                                            <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400">Rank</p>
+                                            <p className="text-xl font-black tabular-nums text-slate-900 dark:text-white">#{leaderboardEntry.position}</p>
+                                        </div>
+                                    )}
+                                    {leaderboardEntry && (
+                                        <div className="rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/70 dark:bg-gray-900/70 backdrop-blur-sm px-5 py-2.5 min-w-[88px] text-center">
+                                            <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400">Points</p>
+                                            <p className="text-xl font-black tabular-nums bg-gradient-to-r from-blue-500 via-cyan-500 to-teal-500 dark:from-blue-400 dark:via-cyan-300 dark:to-teal-300 bg-clip-text text-transparent">{totalPoints}</p>
+                                        </div>
+                                    )}
+
+                                    {/* On mobile the form sits in line with rank & points; on desktop it moves to its own block below */}
+                                    {form.length > 0 && (
+                                        <div className="flex items-center sm:hidden">
+                                            <FormBadge form={form}/>
+                                        </div>
+                                    )}
                                 </div>
                             )}
 
                             {form.length > 0 && (
-                                <div className="flex flex-col items-start sm:items-end gap-2">
+                                <div className="hidden sm:flex flex-col items-end gap-2">
                                     <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400">Recent form</p>
                                     <FormBadge form={form}/>
                                 </div>


### PR DESCRIPTION
On portrait/mobile the recent form badge now sits in line with the
rank and points cards. Desktop/landscape layout is unchanged.