### PR TITLE
Space rank, points and form evenly across screen on mobile

### DIFF
--- a/frontend/app/app/user/[userId]/history/page.tsx
+++ b/frontend/app/app/user/[userId]/history/page.tsx
@@ -90,9 +90,9 @@ export default async function Home({
                     </div>
 
                     {(leaderboardEntry || form.length > 0) && (
-                        <div className="flex flex-col items-start sm:items-end gap-4 shrink-0">
+                        <div className="flex w-full flex-col items-start gap-4 sm:w-auto sm:items-end sm:shrink-0">
                             {(leaderboardEntry || form.length > 0) && (
-                                <div className="flex items-stretch gap-3">
+                                <div className="flex w-full items-stretch justify-between gap-3 sm:w-auto sm:justify-start">
                                     {leaderboardEntry && (
                                         <div className="rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/70 dark:bg-gray-900/70 backdrop-blur-sm px-5 py-2.5 min-w-[88px] text-center">
                                             <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400">Rank</p>


### PR DESCRIPTION
Builds on top of `claude/mobile-form-graphic-layout-ki4w54`.

On portrait/mobile the stats row now spans the full width of the screen, with the **Rank**, **Points** and **Recent form** spread evenly across it (`w-full justify-between`). Desktop/landscape layout is unchanged — the row reverts to its auto-width, left-packed arrangement at the `sm` breakpoint.

https://claude.ai/code/session_01E3iphu7h9MPR4sYchQAv7d

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3iphu7h9MPR4sYchQAv7d)_