### PR TITLE
Show latest form score on the right with a highlight ring

### DIFF
--- a/frontend/app/app/user/[userId]/history/page.tsx
+++ b/frontend/app/app/user/[userId]/history/page.tsx
@@ -110,7 +110,7 @@ export default async function Home({
                                     {form.length > 0 && (
                                         <div className="flex flex-col items-center justify-center gap-1.5 sm:hidden">
                                             <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400">Recent form</p>
-                                            <FormBadge form={form}/>
+                                            <FormBadge form={form} highlightLatest/>
                                         </div>
                                     )}
                                 </div>
@@ -119,7 +119,7 @@ export default async function Home({
                             {form.length > 0 && (
                                 <div className="hidden sm:flex flex-col items-end gap-2">
                                     <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400">Recent form</p>
-                                    <FormBadge form={form}/>
+                                    <FormBadge form={form} highlightLatest/>
                                 </div>
                             )}
                         </div>

--- a/frontend/app/components/leaderboard/form-badge.tsx
+++ b/frontend/app/components/leaderboard/form-badge.tsx
@@ -8,11 +8,14 @@ function dotStyle(points: number | null): string {
     return "bg-slate-900/10 dark:bg-white/10 text-slate-400 dark:text-gray-500"
 }
 
-export default function FormBadge({form}: {form: (number | null)[]}) {
+export default function FormBadge({form, highlightLatest = false}: {form: (number | null)[], highlightLatest?: boolean}) {
+    // Incoming form is most-recent-first; render it reversed so the most recent score sits on the right.
+    const ordered = [...form].reverse()
+    const latestIndex = ordered.length - 1
     return (
         <div className="flex items-center gap-1">
-            {form.map((pts, i) => (
-                <div key={i} className={`h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-black ${dotStyle(pts)}`}>
+            {ordered.map((pts, i) => (
+                <div key={i} className={`h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-black ${dotStyle(pts)} ${highlightLatest && i === latestIndex ? "ring-2 ring-cyan-400 ring-offset-2 ring-offset-slate-50 dark:ring-offset-gray-900" : ""}`}>
                     {pts ?? 0}
                 </div>
             ))}


### PR DESCRIPTION
Two tweaks to the recent-form graphic on the profile page:

- **Most recent score on the right** — the form data is most-recent-first, so `FormBadge` now renders it reversed, putting the latest result at the right-hand end.
- **Highlight ring on the latest** — the most recent dot gets a consistent cyan ring (`ring-2 ring-cyan-400` with a background-matched offset), regardless of that score's own colour, so it's always clear which result is newest.

The ring is opt-in via a new `highlightLatest` prop, so the leaderboard's single-dot form badge is unchanged.

https://claude.ai/code/session_01E3iphu7h9MPR4sYchQAv7d

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3iphu7h9MPR4sYchQAv7d)_