### PR TITLE
Add gold/silver/bronze glows to leaderboard podium places

### DIFF
--- a/frontend/app/components/leaderboard/entry.tsx
+++ b/frontend/app/components/leaderboard/entry.tsx
@@ -4,7 +4,7 @@ import React, {useState} from "react"
 import {LeaderboardInner, LeaderboardInnerMovementEnum} from "@/client"
 import FormBadge from "@/app/components/leaderboard/form-badge"
 import {FlagImage} from "@/app/components/predictions/flag-image"
-import {NEGATIVE_CHIP, NEUTRAL_CHIP, POSITIVE_CHIP} from "@/app/util/css-classes"
+import {NEGATIVE_CHIP, NEUTRAL_CHIP, PODIUM_GLOW, POSITIVE_CHIP} from "@/app/util/css-classes"
 
 interface EntryProps {
     entry: LeaderboardInner
@@ -26,6 +26,7 @@ export default function Entry(props: EntryProps): React.JSX.Element {
 
     const isPodium = props.entry.position <= 3
     const isUser = props.isUser ?? false
+    const podiumGlow = isPodium ? PODIUM_GLOW[props.entry.position as 1 | 2 | 3] : ""
 
     return (
         <div
@@ -34,7 +35,7 @@ export default function Entry(props: EntryProps): React.JSX.Element {
                 isUser
                     ? "bg-gradient-to-r from-blue-500 via-cyan-400 to-teal-300"
                     : isPodium
-                        ? "bg-gradient-to-r from-slate-900/20 to-slate-900/10 dark:from-white/25 dark:to-white/10"
+                        ? podiumGlow
                         : "bg-slate-900/10 dark:bg-white/10"
             } ${isLoading ? "animate-pulse" : "hover:scale-[1.01]"}`}
         >

--- a/frontend/app/util/css-classes.ts
+++ b/frontend/app/util/css-classes.ts
@@ -32,6 +32,17 @@ export const ACTION_PILL_BORDER = "bg-amber-500/40 hover:bg-amber-500/60 dark:bg
 // brand UI. Use for the single most important action on a surface.
 export const ACTION_BUTTON_CLASS = "bg-gradient-to-r from-amber-400 to-orange-500 text-gray-950 font-bold shadow-lg shadow-orange-500/25 transition-transform hover:scale-[1.01]"
 
+// Podium glows for the top three leaderboard places. Each value is the
+// gradient "border" (revealed by the row's 1px padding) plus a coloured glow
+// shadow. Gold is intentionally the most prominent — biggest, brightest glow —
+// with silver and bronze progressively subtler. Warm metallics chosen to read
+// as a podium while still sitting happily next to the cool brand gradient.
+export const PODIUM_GLOW: Record<1 | 2 | 3, string> = {
+    1: "bg-gradient-to-r from-amber-200 via-yellow-400 to-amber-500 shadow-[0_0_28px_-2px_rgba(251,191,36,0.75)] dark:shadow-[0_0_32px_-2px_rgba(251,191,36,0.65)]",
+    2: "bg-gradient-to-r from-slate-200 via-gray-300 to-slate-400 shadow-[0_0_16px_-4px_rgba(148,163,184,0.6)] dark:shadow-[0_0_18px_-4px_rgba(203,213,225,0.5)]",
+    3: "bg-gradient-to-r from-orange-300 via-amber-600 to-orange-700 shadow-[0_0_16px_-4px_rgba(217,119,6,0.6)] dark:shadow-[0_0_18px_-4px_rgba(234,88,12,0.55)]",
+}
+
 // Semantic chips (border + tint + text), used for leaderboard movement etc.
 export const POSITIVE_CHIP = "bg-emerald-500/15 text-emerald-700 border-emerald-500/30 dark:bg-emerald-400/15 dark:text-emerald-300 dark:border-emerald-400/30"
 export const NEGATIVE_CHIP = "bg-rose-500/15 text-rose-700 border-rose-500/30 dark:bg-rose-400/15 dark:text-rose-300 dark:border-rose-400/30"


### PR DESCRIPTION
Give the top three leaderboard rows distinct metallic glows instead of
the shared neutral border. Gold (1st) is the most prominent with a larger,
brighter glow; silver and bronze are progressively subtler. Colours are
defined as PODIUM_GLOW tokens in css-classes.ts to keep the palette in one
place and tuned to sit alongside the cool brand gradient.