### PR TITLE
Improve silver podium glow contrast on light mode

### DIFF
--- a/frontend/app/util/css-classes.ts
+++ b/frontend/app/util/css-classes.ts
@@ -39,7 +39,7 @@ export const ACTION_BUTTON_CLASS = "bg-gradient-to-r from-amber-400 to-orange-50
 // as a podium while still sitting happily next to the cool brand gradient.
 export const PODIUM_GLOW: Record<1 | 2 | 3, string> = {
     1: "bg-gradient-to-r from-amber-200 via-yellow-400 to-amber-500 shadow-[0_0_28px_-2px_rgba(251,191,36,0.75)] dark:shadow-[0_0_32px_-2px_rgba(251,191,36,0.65)]",
-    2: "bg-gradient-to-r from-slate-200 via-gray-300 to-slate-400 shadow-[0_0_16px_-4px_rgba(148,163,184,0.6)] dark:shadow-[0_0_18px_-4px_rgba(203,213,225,0.5)]",
+    2: "bg-gradient-to-r from-slate-300 via-slate-400 to-slate-500 dark:from-slate-200 dark:via-gray-300 dark:to-slate-400 shadow-[0_0_18px_-3px_rgba(100,116,139,0.55)] dark:shadow-[0_0_18px_-4px_rgba(203,213,225,0.5)]",
     3: "bg-gradient-to-r from-orange-300 via-amber-600 to-orange-700 shadow-[0_0_16px_-4px_rgba(217,119,6,0.6)] dark:shadow-[0_0_18px_-4px_rgba(234,88,12,0.55)]",
 }
 


### PR DESCRIPTION
Follow-up to #89.

## Problem
The silver (2nd place) podium glow was tuned for dark mode. Its gradient stops (`slate-200 → gray-300 → slate-400`) and soft `slate-400` glow are too light to read against the white card / `slate-50` page background in **light mode**, so the 2nd-place row looks almost borderless compared to the gold and bronze rows.

## Change
In `PODIUM_GLOW[2]` (`frontend/app/util/css-classes.ts`):
- Darken the **light-mode** gradient to a steel `slate-300 → slate-400 → slate-500` so the metallic border has visible contrast against white.
- Strengthen the light-mode glow to a `slate-500` (`#64748b`) shadow with slightly wider spread.
- Restore the original brighter stops and glow for **dark mode** via `dark:` variants, so dark mode is unchanged.

Gold and bronze are untouched.

https://claude.ai/code/session_01Pff54npMeTUWimFUcFDeJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pff54npMeTUWimFUcFDeJa)_