### PR TITLE
Center Draw label in prediction distribution bar

### DIFF
--- a/frontend/app/components/predictions/distribution-bar.tsx
+++ b/frontend/app/components/predictions/distribution-bar.tsx
@@ -16,9 +16,9 @@ export default function DistributionBar({distribution, homeName, awayName}: {
     const awayShort = SHORT_COUNTRY_NAMES[awayName.toLowerCase()] ?? awayName
     return (
         <div className="mt-4">
-            <div className="flex justify-between text-[10px] uppercase tracking-wider font-semibold mb-1">
+            <div className="relative flex justify-between text-[10px] uppercase tracking-wider font-semibold mb-1">
                 <span className="truncate max-w-[40%] text-cyan-600 dark:text-cyan-400" title={`${homeShort} ${Math.round(homePct)}%`}>{homeShort} {Math.round(homePct)}%</span>
-                <span className="text-slate-500 dark:text-gray-400" title={`Draw ${Math.round(drawPct)}%`}>Draw {Math.round(drawPct)}%</span>
+                <span className="absolute left-1/2 -translate-x-1/2 text-slate-500 dark:text-gray-400" title={`Draw ${Math.round(drawPct)}%`}>Draw {Math.round(drawPct)}%</span>
                 <span className="truncate max-w-[40%] text-right text-indigo-600 dark:text-indigo-400" title={`${awayShort} ${Math.round(awayPct)}%`}>{awayShort} {Math.round(awayPct)}%</span>
             </div>
             <div className="flex h-2 w-full rounded-full overflow-hidden bg-slate-200 dark:bg-white/10">


### PR DESCRIPTION
## Summary

The HOME / DRAW / AWAY labels above the distribution bar on the prediction card were equally spaced rather than aligned as intended. The container used `flex justify-between`, which distributes three flow items evenly — so the **Draw** label only sat in the centre of the *leftover space* between HOME and AWAY, not in the true centre of the bar (and it drifted as the HOME/AWAY label widths changed).

## Change

In `frontend/app/components/predictions/distribution-bar.tsx`:
- Made the label row `relative`.
- Positioned the **Draw** label absolutely at the horizontal centre (`absolute left-1/2 -translate-x-1/2`).

Result:
- **Draw** is now exactly centred in the div.
- **HOME** stays left-aligned and **AWAY** stays right-aligned (still pinned to the edges by `justify-between`).

https://claude.ai/code/session_01S2ERS9KGbDhHJXAbggh9Qz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2ERS9KGbDhHJXAbggh9Qz)_