### PR TITLE
Update streak pill label to 'completed matches predicted' and emoji

### DIFF
--- a/frontend/app/components/points/streak-badges.tsx
+++ b/frontend/app/components/points/streak-badges.tsx
@@ -48,7 +48,7 @@ export function StreakPills({stats}: {stats: StreakStats}): React.JSX.Element | 
     return (
         <>
             {showRate && (
-                <StreakPill icon="🎯" value={`${Math.round(stats.predictionRate * 100)}%`} label="matches predicted" />
+                <StreakPill icon="✅" value={`${Math.round(stats.predictionRate * 100)}%`} label="completed matches predicted" />
             )}
             {showPoints && (
                 <StreakPill icon="🔥" value={stats.pointsStreak} label="scoring streak" hot={stats.pointsStreak >= HOT_STREAK} />


### PR DESCRIPTION
Clarify the prediction-rate pill copy and swap the dartboard for a
checkmark, which better reflects coverage of completed matches rather
than accuracy.

https://claude.ai/code/session_01AWiNy6dEAfyVa6Fqww7Tux