### PR TITLE
Brighten globe + distribution-bar colours to cyan-300 / indigo-400

### DIFF
--- a/frontend/app/components/flags/focused-globe.tsx
+++ b/frontend/app/components/flags/focused-globe.tsx
@@ -570,8 +570,8 @@ function Scene({homeCode, awayCode, venue, enableControls, userStopped, onUserSt
                 <meshBasicMaterial color="#22d3ee" wireframe transparent opacity={0.08}/>
             </mesh>
             <Continents/>
-            {hasHome && <CountryFill code={homeCode} color="#10b981"/>}
-            {hasAway && <CountryFill code={awayCode} color="#f59e0b"/>}
+            {hasHome && <CountryFill code={homeCode} color="#67e8f9"/>}
+            {hasAway && <CountryFill code={awayCode} color="#818cf8"/>}
             {arcs.map((points, i) => (
                 <AnimatedArc key={i} points={points} anim={anim}/>
             ))}

--- a/frontend/app/components/predictions/distribution-bar.tsx
+++ b/frontend/app/components/predictions/distribution-bar.tsx
@@ -17,14 +17,14 @@ export default function DistributionBar({distribution, homeName, awayName}: {
     return (
         <div className="mt-4">
             <div className="relative flex justify-between text-[10px] uppercase tracking-wider font-semibold mb-1">
-                <span className="truncate max-w-[40%] text-emerald-600 dark:text-emerald-400" title={`${homeShort} ${Math.round(homePct)}%`}>{homeShort} {Math.round(homePct)}%</span>
+                <span className="truncate max-w-[40%] text-cyan-600 dark:text-cyan-300" title={`${homeShort} ${Math.round(homePct)}%`}>{homeShort} {Math.round(homePct)}%</span>
                 <span className="absolute left-1/2 -translate-x-1/2 text-slate-500 dark:text-gray-400" title={`Draw ${Math.round(drawPct)}%`}>Draw {Math.round(drawPct)}%</span>
-                <span className="truncate max-w-[40%] text-right text-amber-600 dark:text-amber-400" title={`${awayShort} ${Math.round(awayPct)}%`}>{awayShort} {Math.round(awayPct)}%</span>
+                <span className="truncate max-w-[40%] text-right text-indigo-500 dark:text-indigo-300" title={`${awayShort} ${Math.round(awayPct)}%`}>{awayShort} {Math.round(awayPct)}%</span>
             </div>
             <div className="flex h-2 w-full rounded-full overflow-hidden bg-slate-200 dark:bg-white/10">
-                <div className="bg-emerald-500" style={{width: `${homePct}%`}}/>
+                <div className="bg-cyan-300" style={{width: `${homePct}%`}}/>
                 <div className="bg-slate-400 dark:bg-gray-500" style={{width: `${drawPct}%`}}/>
-                <div className="bg-amber-500" style={{width: `${awayPct}%`}}/>
+                <div className="bg-indigo-400" style={{width: `${awayPct}%`}}/>
             </div>
         </div>
     )


### PR DESCRIPTION
## What

Updates the home/away highlight colours used on the focused globe and the prediction distribution bar.

- **Home:** `#67e8f9` (cyan-300)
- **Away:** `#818cf8` (indigo-400)

## Why

The previous emerald/amber pair was fine, but we wanted to return to the cyan/indigo family that the distribution bar originally used. Plain cyan/indigo, however, didn't pop on the globe — the home cyan blended into the cyan continents/grid and the indigo sat muddily against the dark-navy ocean.

These **brightened** values fix that: the lighter cyan-300 reads as a distinct glowing node against the continents, and the brighter indigo-400 lifts off the navy. Both colours are applied identically to the globe country fills and the distribution-bar segments/labels so the two elements stay visually consistent.

## Changes

- `focused-globe.tsx` — home/away `CountryFill` colours → `#67e8f9` / `#818cf8`
- `distribution-bar.tsx` — home segment `bg-cyan-300`, away segment `bg-indigo-400`, with matching label text colours (draw segment unchanged)

https://claude.ai/code/session_01N5E7nWDh4FHy1UJQjXX34k

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5E7nWDh4FHy1UJQjXX34k)_