### PR TITLE
Declutter points headline card with calmer pill styling

### DIFF
--- a/frontend/app/components/points/headline.tsx
+++ b/frontend/app/components/points/headline.tsx
@@ -6,7 +6,7 @@ import { getConfigWithAuthHeader } from "@/app/api/client-config";
 import { getUserId } from "@/app/auth/jwt-handler";
 import { getPositionForLeague } from "@/app/app/league/get-position-for-league";
 import { FlagImage } from "@/app/components/predictions/flag-image";
-import { StreakPills } from "@/app/components/points/streak-badges";
+import { StreakPills, PILL, PILL_LABEL } from "@/app/components/points/streak-badges";
 import { StreakStats } from "@/app/util/streaks";
 import FormBadge from "@/app/components/leaderboard/form-badge";
 import { getUserForm } from "@/app/components/leaderboard/get-user-form";
@@ -70,7 +70,7 @@ export default async function Headline({ hasLiveMatch, supportedTeamId, streaks 
     const countryNeighbours = country ? countryRankings.slice(Math.max(0, countryIndex - 1), countryIndex + 2) : []
 
     return (
-        <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-2xl shadow-cyan-500/10">
+        <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/10 to-slate-900/[0.03] dark:from-white/10 dark:to-white/[0.03] p-[1px] shadow-xl shadow-cyan-500/5">
             <div className="rounded-3xl bg-white dark:bg-gray-900/80 backdrop-blur-sm px-6 py-7 sm:py-10 text-center">
                 <div className="text-5xl sm:text-7xl font-black leading-none tracking-tight">
                     <span className="bg-gradient-to-r from-blue-500 via-cyan-400 to-teal-300 bg-clip-text text-transparent">
@@ -78,23 +78,23 @@ export default async function Headline({ hasLiveMatch, supportedTeamId, streaks 
                     </span>
                 </div>
                 <div className="mt-2 text-[11px] sm:text-xs font-bold uppercase tracking-[0.25em] text-slate-500 dark:text-gray-400">points</div>
-                <div className="mt-5 flex items-center justify-center gap-3 flex-wrap text-sm">
-                    <span className="inline-flex items-center gap-2 rounded-full bg-slate-900/5 dark:bg-white/5 border border-slate-900/10 dark:border-white/10 px-3.5 py-1.5">
-                        <span className="h-1.5 w-1.5 rounded-full bg-blue-400"/>
+                <div className="mt-6 flex items-center justify-center gap-2 flex-wrap text-sm">
+                    <span className={PILL}>
+                        <span className="h-1 w-1 rounded-full bg-blue-400"/>
                         <span className="font-bold text-slate-900 dark:text-white tabular-nums">#{position ?? "—"}</span>
-                        <span className="text-slate-500 dark:text-gray-400 text-[11px] uppercase tracking-[0.15em]">global</span>
+                        <span className={PILL_LABEL}>global</span>
                     </span>
                     {country && (
                         <Link
                             href="/app/leaderboard/countries"
                             title={`${country.teamName} is ${ordinal(country.position)} of ${countryRankings.length} countries`}
-                            className="inline-flex items-center gap-2.5 rounded-full bg-slate-900/5 dark:bg-white/5 border border-slate-900/10 dark:border-white/10 px-3.5 py-1.5 transition-colors hover:border-cyan-500/40 dark:hover:border-cyan-400/40"
+                            className={`${PILL} transition-colors hover:bg-slate-900/[0.09] dark:hover:bg-white/[0.1]`}
                         >
                             {countryNeighbours.map(entry => {
                                 const isUser = entry.teamId === supportedTeamId
                                 return (
                                     <span key={entry.teamId} className={`inline-flex items-center gap-1.5 ${isUser ? "" : "opacity-50"}`}>
-                                        <FlagImage code={entry.flagCode} name={entry.teamName} size={isUser ? 20 : 16}/>
+                                        <FlagImage code={entry.flagCode} name={entry.teamName} size={isUser ? 18 : 15}/>
                                         <span className={`tabular-nums ${isUser ? "font-black text-slate-900 dark:text-white" : "font-medium text-slate-500 dark:text-gray-400"}`}>
                                             {entry.position}
                                         </span>
@@ -104,16 +104,16 @@ export default async function Headline({ hasLiveMatch, supportedTeamId, streaks 
                         </Link>
                     )}
                     {hasLiveMatch && (
-                        <span className="inline-flex items-center gap-2 rounded-full bg-slate-900/5 dark:bg-white/5 border border-slate-900/10 dark:border-white/10 px-3.5 py-1.5">
-                            <span className="h-1.5 w-1.5 rounded-full bg-red-500 animate-pulse"/>
+                        <span className={PILL}>
+                            <span className="h-1 w-1 rounded-full bg-red-500 animate-pulse"/>
                             <span className="font-bold text-slate-900 dark:text-white tabular-nums">{live}</span>
-                            <span className="text-slate-500 dark:text-gray-400 text-[11px] uppercase tracking-[0.15em]">live</span>
+                            <span className={PILL_LABEL}>live</span>
                         </span>
                     )}
                     <StreakPills stats={streaks} />
                     {form.length > 0 && (
-                        <span className="inline-flex items-center gap-2.5 rounded-full bg-slate-900/5 dark:bg-white/5 border border-slate-900/10 dark:border-white/10 px-3.5 py-1.5">
-                            <span className="text-slate-500 dark:text-gray-400 text-[11px] uppercase tracking-[0.15em]">form</span>
+                        <span className={PILL}>
+                            <span className={PILL_LABEL}>form</span>
                             <FormBadge form={form} highlightLatest />
                         </span>
                     )}

--- a/frontend/app/components/points/streak-badges.tsx
+++ b/frontend/app/components/points/streak-badges.tsx
@@ -10,6 +10,14 @@ const HOT_STREAK = 3
 // anything (100% off a single match isn't worth shouting about).
 const MIN_PLAYED_FOR_RATE = 3
 
+// Shared pill styling so every chip in the points headline reads as one calm,
+// borderless set. A soft tinted fill stands in for the old hard border; PILL
+// bundles the default fill, PILL_BASE leaves it off for tinted variants.
+const PILL_BASE = "inline-flex items-center gap-1.5 rounded-full px-3 py-1"
+const PILL_FILL = "bg-slate-900/[0.05] dark:bg-white/[0.06]"
+export const PILL = `${PILL_BASE} ${PILL_FILL}`
+export const PILL_LABEL = "text-slate-500 dark:text-gray-400 text-[11px] uppercase tracking-[0.15em]"
+
 function StreakPill({
     icon,
     value,
@@ -24,15 +32,13 @@ function StreakPill({
     return (
         <span
             className={
-                "inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm border " +
-                (hot
-                    ? "border-amber-500/30 bg-amber-500/10 dark:border-amber-400/30 dark:bg-amber-400/10"
-                    : "border-slate-900/10 bg-slate-900/5 dark:border-white/10 dark:bg-white/5")
+                `${PILL_BASE} text-sm ` +
+                (hot ? "bg-amber-500/10 dark:bg-amber-400/10" : PILL_FILL)
             }
         >
             <span className={hot ? "animate-pulse" : ""} aria-hidden>{icon}</span>
             <span className={`font-bold tabular-nums ${hot ? "text-amber-600 dark:text-amber-300" : "text-slate-900 dark:text-white"}`}>{value}</span>
-            <span className="text-slate-500 dark:text-gray-400 text-[11px] uppercase tracking-[0.15em]">{label}</span>
+            <span className={PILL_LABEL}>{label}</span>
         </span>
     )
 }


### PR DESCRIPTION
Drop the hard borders from the headline stat pills in favour of a soft
tinted fill, lighten the card's gradient border and shadow, shrink the
status dots and tighten the spacing. All stats are retained; this is a
purely visual cleanup. Shared PILL/PILL_LABEL styles keep the headline
and streak pills in sync.