### PR TITLE
Relocate live and prediction-rate pills out of the headline row

### DIFF
--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -102,7 +102,7 @@ const Home = async ({searchParams}: {searchParams: Promise<Record<string, string
 
                     <section id="matches" className="space-y-4">
                         <SectionHeading title="Matches" count={liveMatches.length + upcomingMatches.length} action={<MatchesHelp/>}/>
-                    <PredictionPanel liveMatches={liveMatches} upcomingMatches={upcomingMatches} completedMatches={recentCompleted} historyHref={historyHref} userChips={userChips} />
+                    <PredictionPanel liveMatches={liveMatches} upcomingMatches={upcomingMatches} completedMatches={recentCompleted} historyHref={historyHref} userChips={userChips} streaks={streaks} />
                 </section>
 
                 <section className="space-y-4">

--- a/frontend/app/components/points/headline.tsx
+++ b/frontend/app/components/points/headline.tsx
@@ -6,7 +6,7 @@ import { getConfigWithAuthHeader } from "@/app/api/client-config";
 import { getUserId } from "@/app/auth/jwt-handler";
 import { getPositionForLeague } from "@/app/app/league/get-position-for-league";
 import { FlagImage } from "@/app/components/predictions/flag-image";
-import { StreakPills, PILL, PILL_LABEL } from "@/app/components/points/streak-badges";
+import { ScoringStreakPill } from "@/app/components/points/streak-badges";
 import { StreakStats } from "@/app/util/streaks";
 import FormBadge from "@/app/components/leaderboard/form-badge";
 import { getUserForm } from "@/app/components/leaderboard/get-user-form";
@@ -70,31 +70,42 @@ export default async function Headline({ hasLiveMatch, supportedTeamId, streaks 
     const countryNeighbours = country ? countryRankings.slice(Math.max(0, countryIndex - 1), countryIndex + 2) : []
 
     return (
-        <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/10 to-slate-900/[0.03] dark:from-white/10 dark:to-white/[0.03] p-[1px] shadow-xl shadow-cyan-500/5">
+        <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-2xl shadow-cyan-500/10">
             <div className="rounded-3xl bg-white dark:bg-gray-900/80 backdrop-blur-sm px-6 py-7 sm:py-10 text-center">
-                <div className="text-5xl sm:text-7xl font-black leading-none tracking-tight">
-                    <span className="bg-gradient-to-r from-blue-500 via-cyan-400 to-teal-300 bg-clip-text text-transparent">
-                        <CountUpWrapped end={total} />
-                    </span>
+                {/* The points total stays dead-centre; the live pill rides alongside
+                    it on the right without nudging the number off-centre. */}
+                <div className="relative">
+                    <div className="text-5xl sm:text-7xl font-black leading-none tracking-tight">
+                        <span className="bg-gradient-to-r from-blue-500 via-cyan-400 to-teal-300 bg-clip-text text-transparent">
+                            <CountUpWrapped end={total} />
+                        </span>
+                    </div>
+                    {hasLiveMatch && (
+                        <span className="absolute right-0 top-1/2 -translate-y-1/2 inline-flex items-center gap-2 rounded-full bg-slate-900/5 dark:bg-white/5 border border-slate-900/10 dark:border-white/10 px-3.5 py-1.5 text-sm">
+                            <span className="h-1.5 w-1.5 rounded-full bg-red-500 animate-pulse"/>
+                            <span className="font-bold text-slate-900 dark:text-white tabular-nums">{live}</span>
+                            <span className="text-slate-500 dark:text-gray-400 text-[11px] uppercase tracking-[0.15em]">live</span>
+                        </span>
+                    )}
                 </div>
                 <div className="mt-2 text-[11px] sm:text-xs font-bold uppercase tracking-[0.25em] text-slate-500 dark:text-gray-400">points</div>
-                <div className="mt-6 flex items-center justify-center gap-2 flex-wrap text-sm">
-                    <span className={PILL}>
-                        <span className="h-1 w-1 rounded-full bg-blue-400"/>
+                <div className="mt-5 flex items-center justify-center gap-3 flex-wrap text-sm">
+                    <span className="inline-flex items-center gap-2 rounded-full bg-slate-900/5 dark:bg-white/5 border border-slate-900/10 dark:border-white/10 px-3.5 py-1.5">
+                        <span className="h-1.5 w-1.5 rounded-full bg-blue-400"/>
                         <span className="font-bold text-slate-900 dark:text-white tabular-nums">#{position ?? "—"}</span>
-                        <span className={PILL_LABEL}>global</span>
+                        <span className="text-slate-500 dark:text-gray-400 text-[11px] uppercase tracking-[0.15em]">global</span>
                     </span>
                     {country && (
                         <Link
                             href="/app/leaderboard/countries"
                             title={`${country.teamName} is ${ordinal(country.position)} of ${countryRankings.length} countries`}
-                            className={`${PILL} transition-colors hover:bg-slate-900/[0.09] dark:hover:bg-white/[0.1]`}
+                            className="inline-flex items-center gap-2.5 rounded-full bg-slate-900/5 dark:bg-white/5 border border-slate-900/10 dark:border-white/10 px-3.5 py-1.5 transition-colors hover:border-cyan-500/40 dark:hover:border-cyan-400/40"
                         >
                             {countryNeighbours.map(entry => {
                                 const isUser = entry.teamId === supportedTeamId
                                 return (
                                     <span key={entry.teamId} className={`inline-flex items-center gap-1.5 ${isUser ? "" : "opacity-50"}`}>
-                                        <FlagImage code={entry.flagCode} name={entry.teamName} size={isUser ? 18 : 15}/>
+                                        <FlagImage code={entry.flagCode} name={entry.teamName} size={isUser ? 20 : 16}/>
                                         <span className={`tabular-nums ${isUser ? "font-black text-slate-900 dark:text-white" : "font-medium text-slate-500 dark:text-gray-400"}`}>
                                             {entry.position}
                                         </span>
@@ -103,17 +114,10 @@ export default async function Headline({ hasLiveMatch, supportedTeamId, streaks 
                             })}
                         </Link>
                     )}
-                    {hasLiveMatch && (
-                        <span className={PILL}>
-                            <span className="h-1 w-1 rounded-full bg-red-500 animate-pulse"/>
-                            <span className="font-bold text-slate-900 dark:text-white tabular-nums">{live}</span>
-                            <span className={PILL_LABEL}>live</span>
-                        </span>
-                    )}
-                    <StreakPills stats={streaks} />
+                    <ScoringStreakPill stats={streaks} />
                     {form.length > 0 && (
-                        <span className={PILL}>
-                            <span className={PILL_LABEL}>form</span>
+                        <span className="inline-flex items-center gap-2.5 rounded-full bg-slate-900/5 dark:bg-white/5 border border-slate-900/10 dark:border-white/10 px-3.5 py-1.5">
+                            <span className="text-slate-500 dark:text-gray-400 text-[11px] uppercase tracking-[0.15em]">form</span>
                             <FormBadge form={form} highlightLatest />
                         </span>
                     )}

--- a/frontend/app/components/points/streak-badges.tsx
+++ b/frontend/app/components/points/streak-badges.tsx
@@ -10,14 +10,6 @@ const HOT_STREAK = 3
 // anything (100% off a single match isn't worth shouting about).
 const MIN_PLAYED_FOR_RATE = 3
 
-// Shared pill styling so every chip in the points headline reads as one calm,
-// borderless set. A soft tinted fill stands in for the old hard border; PILL
-// bundles the default fill, PILL_BASE leaves it off for tinted variants.
-const PILL_BASE = "inline-flex items-center gap-1.5 rounded-full px-3 py-1"
-const PILL_FILL = "bg-slate-900/[0.05] dark:bg-white/[0.06]"
-export const PILL = `${PILL_BASE} ${PILL_FILL}`
-export const PILL_LABEL = "text-slate-500 dark:text-gray-400 text-[11px] uppercase tracking-[0.15em]"
-
 function StreakPill({
     icon,
     value,
@@ -32,33 +24,44 @@ function StreakPill({
     return (
         <span
             className={
-                `${PILL_BASE} text-sm ` +
-                (hot ? "bg-amber-500/10 dark:bg-amber-400/10" : PILL_FILL)
+                "inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm border " +
+                (hot
+                    ? "border-amber-500/30 bg-amber-500/10 dark:border-amber-400/30 dark:bg-amber-400/10"
+                    : "border-slate-900/10 bg-slate-900/5 dark:border-white/10 dark:bg-white/5")
             }
         >
             <span className={hot ? "animate-pulse" : ""} aria-hidden>{icon}</span>
             <span className={`font-bold tabular-nums ${hot ? "text-amber-600 dark:text-amber-300" : "text-slate-900 dark:text-white"}`}>{value}</span>
-            <span className={PILL_LABEL}>{label}</span>
+            <span className="text-slate-500 dark:text-gray-400 text-[11px] uppercase tracking-[0.15em]">{label}</span>
         </span>
     )
 }
 
+// The prediction-rate pill on its own, so it can live apart from the points
+// headline (e.g. right-aligned in the Completed matches row header). Renders
+// nothing until there are enough games for the percentage to mean anything.
+export function PredictionRatePill({stats}: {stats: StreakStats}): React.JSX.Element | null {
+    if (stats.played < MIN_PLAYED_FOR_RATE) return null
+    return <StreakPill icon="✅" value={`${Math.round(stats.predictionRate * 100)}%`} label="prediction rate" />
+}
+
+// The scoring-streak pill on its own. Hidden until a run is at least two-deep.
+export function ScoringStreakPill({stats}: {stats: StreakStats}): React.JSX.Element | null {
+    if (stats.pointsStreak < MIN_POINTS_STREAK) return null
+    return <StreakPill icon="🔥" value={stats.pointsStreak} label="scoring streak" hot={stats.pointsStreak >= HOT_STREAK} />
+}
+
 // The bare streak pills, with no wrapper, so they can be dropped straight into
-// an existing pill row (e.g. the points headline). Renders nothing when neither
-// stat is meaningful yet.
+// an existing pill row. Renders nothing when neither stat is meaningful yet.
 export function StreakPills({stats}: {stats: StreakStats}): React.JSX.Element | null {
-    const showRate = stats.played >= MIN_PLAYED_FOR_RATE
-    const showPoints = stats.pointsStreak >= MIN_POINTS_STREAK
-    if (!showRate && !showPoints) return null
+    const rate = PredictionRatePill({stats})
+    const points = ScoringStreakPill({stats})
+    if (!rate && !points) return null
 
     return (
         <>
-            {showRate && (
-                <StreakPill icon="✅" value={`${Math.round(stats.predictionRate * 100)}%`} label="prediction rate" />
-            )}
-            {showPoints && (
-                <StreakPill icon="🔥" value={stats.pointsStreak} label="scoring streak" hot={stats.pointsStreak >= HOT_STREAK} />
-            )}
+            {rate}
+            {points}
         </>
     )
 }

--- a/frontend/app/components/predictions/match-strip.tsx
+++ b/frontend/app/components/predictions/match-strip.tsx
@@ -7,6 +7,8 @@ import {LocalTime} from "@/app/components/predictions/local-time"
 import {FlagImage} from "@/app/components/predictions/flag-image"
 import {ACTION_PILL_BORDER} from "@/app/util/css-classes"
 import {PointsPill} from "@/app/components/predictions/chip-impact"
+import {PredictionRatePill} from "@/app/components/points/streak-badges"
+import type {StreakStats} from "@/app/util/streaks"
 
 // Power-ups worth surfacing on the pill. Crowd has its own "? - ?" treatment.
 const CHIP_GLYPH: Partial<Record<Chip, string>> = {
@@ -25,9 +27,11 @@ interface MatchStripProps {
     historyHref: string
     selectedId: string
     onSelect: (id: string) => void
+    /** Drives the prediction-rate pill in the Completed row header. */
+    streaks: StreakStats
 }
 
-export default function MatchStrip({liveMatches, upcomingMatches, completedMatches, historyHref, selectedId, onSelect}: MatchStripProps) {
+export default function MatchStrip({liveMatches, upcomingMatches, completedMatches, historyHref, selectedId, onSelect, streaks}: MatchStripProps) {
     return (
         <div className="space-y-4">
             {liveMatches.length > 0 && (
@@ -37,7 +41,7 @@ export default function MatchStrip({liveMatches, upcomingMatches, completedMatch
                 <StripRow title="Upcoming" matches={upcomingMatches} selectedId={selectedId} onSelect={onSelect}/>
             )}
             {completedMatches.length > 0 && (
-                <CompletedRow matches={completedMatches} historyHref={historyHref}/>
+                <CompletedRow matches={completedMatches} historyHref={historyHref} streaks={streaks}/>
             )}
         </div>
     )
@@ -112,10 +116,10 @@ function StripRow({title, matches, selectedId, onSelect, live}: {
 // Completed matches aren't predictable, so their pills link out to the match's
 // result/predictions page (like the history cards) rather than selecting into
 // the card above. The trailing "View all" pill opens the full history.
-function CompletedRow({matches, historyHref}: {matches: Match[]; historyHref: string}) {
+function CompletedRow({matches, historyHref, streaks}: {matches: Match[]; historyHref: string; streaks: StreakStats}) {
     return (
         <div>
-            <RowHeader title="Completed"/>
+            <RowHeader title="Completed" action={<PredictionRatePill stats={streaks}/>}/>
             <div
                 className="flex gap-3 overflow-x-auto pb-2 px-4 sm:px-6 snap-x snap-mandatory scrollbar-thin"
                 style={{scrollbarWidth: "thin"}}
@@ -143,11 +147,12 @@ function CompletedRow({matches, historyHref}: {matches: Match[]; historyHref: st
     )
 }
 
-function RowHeader({title, live}: {title: string; live?: boolean}) {
+function RowHeader({title, live, action}: {title: string; live?: boolean; action?: React.ReactNode}) {
     return (
         <div className="flex items-center gap-2 mb-2 px-4 sm:px-6">
             {live && <span className="h-2 w-2 rounded-full bg-red-500 animate-pulse"/>}
             <h3 className="text-sm font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400">{title}</h3>
+            {action && <div className="ml-auto">{action}</div>}
         </div>
     )
 }

--- a/frontend/app/components/predictions/prediction-panel.tsx
+++ b/frontend/app/components/predictions/prediction-panel.tsx
@@ -11,6 +11,7 @@ import {MatchScoreOverlay} from "@/app/components/predictions/match-score-overla
 import {PointsPill} from "@/app/components/predictions/chip-impact"
 import {useMatchSelection} from "@/app/components/predictions/match-selection"
 import type {UserChips} from "@/app/components/predictions/get-user-chips"
+import type {StreakStats} from "@/app/util/streaks"
 
 const ROUND_LABEL: Record<MatchRoundEnum, string> = {
     GROUP_STAGE: "Group Stage",
@@ -26,9 +27,10 @@ interface PredictionPanelProps {
     completedMatches: Match[]
     historyHref: string
     userChips: UserChips
+    streaks: StreakStats
 }
 
-export default function PredictionPanel({liveMatches, upcomingMatches, completedMatches, historyHref, userChips}: PredictionPanelProps): React.JSX.Element {
+export default function PredictionPanel({liveMatches, upcomingMatches, completedMatches, historyHref, userChips, streaks}: PredictionPanelProps): React.JSX.Element {
     const allMatches = useMemo(() => [...liveMatches, ...upcomingMatches], [liveMatches, upcomingMatches])
     const {selectedId, setSelectedId} = useMatchSelection()
     const [chips, setChips] = useState<UserChips>(userChips)
@@ -121,6 +123,7 @@ export default function PredictionPanel({liveMatches, upcomingMatches, completed
                 historyHref={historyHref}
                 selectedId={selected.matchId}
                 onSelect={setSelectedId}
+                streaks={streaks}
             />
         </div>
     )


### PR DESCRIPTION
Rebased off `main` (which now includes the unfinished restyle from #97). This PR undoes that restyle and makes two targeted layout changes to the points headline.

## What changed

**1. Live pill now sits beside the centred points total**
The live-points pill moves up onto the same row as the big total. The total stays dead-centre (the pill is absolutely positioned at the right edge, vertically centred), so the number never shifts whether or not a live match is in play. It's removed from the lower pill row.

**2. Prediction-rate pill moves into the Completed matches row header**
Right-aligned in the `COMPLETED` row header, reading like `COMPLETED ........ ✅ 82% PREDICTION RATE`. It keeps the existing rule of only appearing once you've played ≥3 completed matches.

## Implementation notes
- Split `StreakPills` into `PredictionRatePill` / `ScoringStreakPill` so each pill can live where it belongs. The headline now renders only the scoring-streak pill; the history page's `StreakBadges` still shows both (unchanged).
- `RowHeader` gained an optional right-aligned `action` slot; `streaks` is threaded `page.tsx → PredictionPanel → MatchStrip → CompletedRow`.
- Undoes the "calmer pill styling" restyle that landed via #97.

Typecheck passes.

https://claude.ai/code/session_01Y8Yts5kjYoKyQYcXdSeC36

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8Yts5kjYoKyQYcXdSeC36)_