### PR TITLE
Revert "Fill host country with its flag on the prediction globe (#99)"

### DIFF
--- a/frontend/app/components/flags/focused-globe.tsx
+++ b/frontend/app/components/flags/focused-globe.tsx
@@ -335,58 +335,6 @@ function CountryFill({code, color}: {code: string; color: string}) {
     )
 }
 
-// Fills the host nation's landmass with its own flag, extruded off the globe
-// exactly like the playing-country highlights and fading in the same way. Used
-// only when the host country is not itself playing the match (when it is, the
-// home/away colour fill takes precedence).
-function CountryFlagFill({code}: {code: string}) {
-    const geometry = useMemo(
-        () => buildCountryFillGeometry(code, COUNTRY_FILL_BASE, COUNTRY_FILL_HEIGHT, true),
-        [code],
-    )
-    const texture = useTexture(`https://flagcdn.com/w320/${code}.png`) as THREE.Texture
-    useMemo(() => {
-        texture.colorSpace = THREE.SRGBColorSpace
-        texture.wrapS = THREE.ClampToEdgeWrapping
-        texture.wrapT = THREE.ClampToEdgeWrapping
-        texture.needsUpdate = true
-    }, [texture])
-
-    const materialRef = useRef<THREE.MeshStandardMaterial>(null)
-    const elapsed = useRef(0)
-
-    useEffect(() => {
-        elapsed.current = 0
-    }, [code])
-
-    useFrame((_, delta) => {
-        if (!materialRef.current) return
-        if (elapsed.current >= COUNTRY_FILL_FADE_SECONDS) return
-        elapsed.current = Math.min(COUNTRY_FILL_FADE_SECONDS, elapsed.current + delta)
-        const t = easeInOut(elapsed.current / COUNTRY_FILL_FADE_SECONDS)
-        materialRef.current.opacity = t * COUNTRY_FILL_OPACITY
-    })
-
-    if (!geometry) return null
-    return (
-        <mesh geometry={geometry}>
-            <meshStandardMaterial
-                ref={materialRef}
-                map={texture}
-                emissive="#ffffff"
-                emissiveMap={texture}
-                emissiveIntensity={0.25}
-                roughness={0.5}
-                metalness={0.1}
-                transparent
-                opacity={0}
-                side={THREE.DoubleSide}
-                toneMapped={false}
-            />
-        </mesh>
-    )
-}
-
 function mirrorHorizontally(source: THREE.Texture): THREE.Texture {
     const tex = source.clone()
     tex.wrapS = THREE.ClampToEdgeWrapping
@@ -556,14 +504,6 @@ function Scene({homeCode, awayCode, venue, enableControls, userStopped, onUserSt
         setIntroDone(false)
     }, [homeCode, awayCode, stadium])
 
-    // The host nation, the team code it extrudes under, and whether it is one of
-    // the two playing teams. When the host is not playing we extrude it anyway to
-    // fill its landmass with its flag, so it always stands proud of the globe.
-    const hostCode = stadium ? HOST_NATION_CODE[stadium.country] : undefined
-    const hostIsPlaying = Boolean(hostCode) && (hostCode === homeCode || hostCode === awayCode)
-    const showHostFlag = Boolean(hostCode) && !hostIsPlaying && hasCountryFill(hostCode as string)
-    const hostExtruded = hostIsPlaying || showHostFlag
-
     const {arcs, aPos, bPos, stadiumPos, tourLegs} = useMemo(() => {
         const hc = COUNTRY_COORDS[homeCode]
         const ac = COUNTRY_COORDS[awayCode]
@@ -575,9 +515,10 @@ function Scene({homeCode, awayCode, venue, enableControls, userStopped, onUserSt
         const bRadius = countryGroundRadius(awayCode)
         if (stadium) {
             const sDir = latLngToVec3(stadium.lat, stadium.lng, 1)
-            // The venue always sits in a host nation; that host is extruded (by
-            // the colour fill when it plays, otherwise by its flag fill), so rest
-            // the stadium on the raised top.
+            // The venue always sits in a host nation; if that host is playing it
+            // is extruded, so rest the stadium on the raised top.
+            const hostCode = HOST_NATION_CODE[stadium.country]
+            const hostExtruded = hostCode === homeCode || hostCode === awayCode
             const sRadius = hostExtruded ? COUNTRY_FILL_TOP : GLOBE_RADIUS + STADIUM_BASE_OFFSET
             const arcHome = visibleArc(aDir, sDir, aRadius, sRadius)
             const arcAway = visibleArc(bDir, sDir, bRadius, sRadius)
@@ -597,7 +538,7 @@ function Scene({homeCode, awayCode, venue, enableControls, userStopped, onUserSt
             stadiumPos: undefined,
             tourLegs: [arcHA, [...arcHA].reverse()],
         }
-    }, [homeCode, awayCode, stadium, hostExtruded])
+    }, [homeCode, awayCode, stadium])
 
     const hasHome = Boolean(COUNTRY_COORDS[homeCode])
     const hasAway = Boolean(COUNTRY_COORDS[awayCode])
@@ -631,9 +572,6 @@ function Scene({homeCode, awayCode, venue, enableControls, userStopped, onUserSt
             <Continents/>
             {hasHome && <CountryFill code={homeCode} color="#67e8f9"/>}
             {hasAway && <CountryFill code={awayCode} color="#818cf8"/>}
-            <React.Suspense fallback={null}>
-                {showHostFlag && <CountryFlagFill code={hostCode as string}/>}
-            </React.Suspense>
             {arcs.map((points, i) => (
                 <AnimatedArc key={i} points={points} anim={anim}/>
             ))}

--- a/frontend/app/components/flags/globe-utils.ts
+++ b/frontend/app/components/flags/globe-utils.ts
@@ -106,62 +106,27 @@ function getCountryFeatures(): Map<string, Feature<Polygon | MultiPolygon>> {
     return countryFeatures
 }
 
-// Geographic bounds used to project a flag image across a country's landmass.
-// When a country straddles the antimeridian (raw longitude span > 180°, as the
-// US does via the Aleutians) longitudes west of 0 are wrapped by +360 so the
-// landmass stays contiguous and the flag maps onto it sensibly.
-type LngLatBounds = {minLng: number; maxLng: number; minLat: number; maxLat: number; wrap: boolean}
-
-function computeLngLatBounds(polygons: Position[][][]): LngLatBounds {
-    let rawMin = Infinity, rawMax = -Infinity
-    for (const polygon of polygons) for (const ring of polygon) for (const [lng] of ring) {
-        if (lng < rawMin) rawMin = lng
-        if (lng > rawMax) rawMax = lng
-    }
-    const wrap = rawMax - rawMin > 180
-    let minLng = Infinity, maxLng = -Infinity, minLat = Infinity, maxLat = -Infinity
-    for (const polygon of polygons) for (const ring of polygon) for (const [lng, lat] of ring) {
-        const x = wrap && lng < 0 ? lng + 360 : lng
-        if (x < minLng) minLng = x
-        if (x > maxLng) maxLng = x
-        if (lat < minLat) minLat = lat
-        if (lat > maxLat) maxLat = lat
-    }
-    return {minLng, maxLng, minLat, maxLat, wrap}
-}
-
-function uvForPoint(p: THREE.Vector2, bounds: LngLatBounds): [number, number] {
-    const lng = bounds.wrap && p.x < 0 ? p.x + 360 : p.x
-    const u = (lng - bounds.minLng) / (bounds.maxLng - bounds.minLng)
-    const v = (p.y - bounds.minLat) / (bounds.maxLat - bounds.minLat)
-    return [u, v]
-}
-
 // Tessellate a flat (lng/lat) triangle, projecting each vertex onto the sphere.
 // Subdividing keeps the filled surface hugging the globe instead of cutting a
 // flat chord through it (which would sink below the surface for large countries).
-// When `uvOut` is supplied, an equirectangular UV per vertex is emitted too so a
-// flag texture can be stretched across the country's bounding box.
 function emitProjectedTriangle(
     a: THREE.Vector2, b: THREE.Vector2, c: THREE.Vector2,
     radius: number, depth: number, positions: number[],
-    uvOut?: {uvs: number[]; bounds: LngLatBounds},
 ) {
     if (depth <= 0) {
         for (const p of [a, b, c]) {
             const v = latLngToVec3(p.y, p.x, radius)
             positions.push(v.x, v.y, v.z)
-            if (uvOut) uvOut.uvs.push(...uvForPoint(p, uvOut.bounds))
         }
         return
     }
     const ab = a.clone().add(b).multiplyScalar(0.5)
     const bc = b.clone().add(c).multiplyScalar(0.5)
     const ca = c.clone().add(a).multiplyScalar(0.5)
-    emitProjectedTriangle(a, ab, ca, radius, depth - 1, positions, uvOut)
-    emitProjectedTriangle(ab, b, bc, radius, depth - 1, positions, uvOut)
-    emitProjectedTriangle(ca, bc, c, radius, depth - 1, positions, uvOut)
-    emitProjectedTriangle(ab, bc, ca, radius, depth - 1, positions, uvOut)
+    emitProjectedTriangle(a, ab, ca, radius, depth - 1, positions)
+    emitProjectedTriangle(ab, b, bc, radius, depth - 1, positions)
+    emitProjectedTriangle(ca, bc, c, radius, depth - 1, positions)
+    emitProjectedTriangle(ab, bc, ca, radius, depth - 1, positions)
 }
 
 // Emits the side wall for one ring edge as two triangles spanning from the
@@ -169,7 +134,6 @@ function emitProjectedTriangle(
 function emitWallSegment(
     a: THREE.Vector2, b: THREE.Vector2,
     baseRadius: number, topRadius: number, positions: number[],
-    uvOut?: {uvs: number[]; bounds: LngLatBounds},
 ) {
     const baseA = latLngToVec3(a.y, a.x, baseRadius)
     const baseB = latLngToVec3(b.y, b.x, baseRadius)
@@ -177,21 +141,14 @@ function emitWallSegment(
     const topB = latLngToVec3(b.y, b.x, topRadius)
     positions.push(baseA.x, baseA.y, baseA.z, baseB.x, baseB.y, baseB.z, topB.x, topB.y, topB.z)
     positions.push(baseA.x, baseA.y, baseA.z, topB.x, topB.y, topB.z, topA.x, topA.y, topA.z)
-    if (uvOut) {
-        const uvA = uvForPoint(a, uvOut.bounds)
-        const uvB = uvForPoint(b, uvOut.bounds)
-        uvOut.uvs.push(...uvA, ...uvB, ...uvB)
-        uvOut.uvs.push(...uvA, ...uvB, ...uvA)
-    }
 }
 
 // Builds a filled, slightly extruded geometry for a single country's landmass:
 // a triangulated top cap raised `height` above the globe surface, plus side
 // walls dropping back down to it. Returns null when the country is not present
-// in the dataset. When `withUv` is set, a `uv` attribute is added that projects
-// a flag image across the country's geographic bounding box.
+// in the dataset.
 export function buildCountryFillGeometry(
-    code: string, baseRadius: number, height: number, withUv = false,
+    code: string, baseRadius: number, height: number,
 ): THREE.BufferGeometry | null {
     const geometry = UK_NATION_GEOMETRY[code] ?? getCountryFeatures().get(ALPHA2_TO_ISO_NUM[code])?.geometry
     if (!geometry) return null
@@ -201,7 +158,6 @@ export function buildCountryFillGeometry(
         geometry.type === "Polygon" ? [geometry.coordinates] : geometry.coordinates
 
     const positions: number[] = []
-    const uvOut = withUv ? {uvs: [] as number[], bounds: computeLngLatBounds(polygons)} : undefined
     for (const polygon of polygons) {
         const rings = polygon.map(ring => {
             const pts = ring.map(p => new THREE.Vector2(p[0], p[1]))
@@ -215,12 +171,12 @@ export function buildCountryFillGeometry(
         const faces = THREE.ShapeUtils.triangulateShape(contour, holes)
         const all = [...contour, ...holes.flat()]
         for (const [i, j, k] of faces) {
-            emitProjectedTriangle(all[i], all[j], all[k], topRadius, 2, positions, uvOut)
+            emitProjectedTriangle(all[i], all[j], all[k], topRadius, 2, positions)
         }
 
         for (const ring of rings) {
             for (let i = 0; i < ring.length; i++) {
-                emitWallSegment(ring[i], ring[(i + 1) % ring.length], baseRadius, topRadius, positions, uvOut)
+                emitWallSegment(ring[i], ring[(i + 1) % ring.length], baseRadius, topRadius, positions)
             }
         }
     }
@@ -228,7 +184,6 @@ export function buildCountryFillGeometry(
     if (positions.length === 0) return null
     const geom = new THREE.BufferGeometry()
     geom.setAttribute("position", new THREE.Float32BufferAttribute(positions, 3))
-    if (uvOut) geom.setAttribute("uv", new THREE.Float32BufferAttribute(uvOut.uvs, 2))
     geom.computeVertexNormals()
     return geom
 }


### PR DESCRIPTION
This reverts commit ff7a422 ("Fill host country with its flag on the prediction globe (#99)"), removing the flag fill from the country outline on the prediction globe.

Restores `frontend/app/components/flags/focused-globe.tsx` and `frontend/app/components/flags/globe-utils.ts` to their prior state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSGwqVn8TMsiYvQvhW5RAb)_