### PR TITLE
Add live group standings page

### DIFF
--- a/contract/api-contract.yaml
+++ b/contract/api-contract.yaml
@@ -191,6 +191,92 @@ components:
         flagCode:
           description: Team flag uri
           type: string
+        group:
+          description: Group letter (A-L) the team belongs to in the group stage
+          type: string
+    groupStandingRow:
+      type: object
+      required:
+        - position
+        - teamId
+        - teamName
+        - flagCode
+        - group
+        - played
+        - won
+        - drawn
+        - lost
+        - goalsFor
+        - goalsAgainst
+        - goalDifference
+        - points
+      properties:
+        position:
+          description: Position within the group (1-4) or, for the third-placed table, the overall third-placed ranking
+          type: integer
+          format: int32
+        teamId:
+          type: string
+        teamName:
+          type: string
+        flagCode:
+          type: string
+        group:
+          description: Group letter (A-L)
+          type: string
+        played:
+          type: integer
+          format: int32
+        won:
+          type: integer
+          format: int32
+        drawn:
+          type: integer
+          format: int32
+        lost:
+          type: integer
+          format: int32
+        goalsFor:
+          type: integer
+          format: int32
+        goalsAgainst:
+          type: integer
+          format: int32
+        goalDifference:
+          type: integer
+          format: int32
+        points:
+          type: integer
+          format: int32
+    groupStanding:
+      type: object
+      required:
+        - group
+        - standings
+      properties:
+        group:
+          description: Group letter (A-L)
+          type: string
+        standings:
+          type: array
+          items:
+            $ref: '#/components/schemas/groupStandingRow'
+    standings:
+      type: object
+      required:
+        - groups
+        - thirdPlaced
+      properties:
+        groups:
+          description: Standings for each of the 12 groups, ordered A-L
+          type: array
+          items:
+            $ref: '#/components/schemas/groupStanding'
+        thirdPlaced:
+          description: Ranking of the third-placed team from every group, as they stand
+          type: array
+          items:
+            $ref: '#/components/schemas/groupStandingRow'
     leaderboard:
       type: array
       items:
@@ -348,6 +434,25 @@ x-amazon-apigateway-request-validators:
     validateRequestParameters: true
     validateRequestBody: true
 paths:
+  /standings:
+    get:
+      tags:
+        - standings
+      operationId: getStandings
+      description: Group stage standings (as they stand, including live scores) plus the third-placed team ranking
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${apiHandlerArn}/invocations"
+        credentials: "${apiGatewayRoleArn}"
+        payloadFormatVersion: "1.0"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/standings'
   /team:
     get:
       tags:

--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -101,7 +101,18 @@ const Home = async ({searchParams}: {searchParams: Promise<Record<string, string
                     <HeadlineSuspense tournamentStarted={tournamentStarted} nextKickoff={tournamentState?.nextKickoff} hasLiveMatch={liveMatches.length > 0} supportedTeamId={profile?.supportedTeamId} streaks={streaks} />
 
                     <section id="matches" className="space-y-4">
-                        <SectionHeading title="Matches" count={liveMatches.length + upcomingMatches.length} action={<MatchesHelp/>}/>
+                        <SectionHeading
+                            title="Matches"
+                            count={liveMatches.length + upcomingMatches.length}
+                            action={
+                                <div className="flex items-center gap-3">
+                                    <Link href="/app/standings" className="text-xs font-semibold text-cyan-600 dark:text-cyan-300 hover:text-cyan-700 dark:hover:text-cyan-200 transition-colors">
+                                        Standings →
+                                    </Link>
+                                    <MatchesHelp/>
+                                </div>
+                            }
+                        />
                     <PredictionPanel liveMatches={liveMatches} upcomingMatches={upcomingMatches} completedMatches={recentCompleted} historyHref={historyHref} userChips={userChips} streaks={streaks} />
                 </section>
 

--- a/frontend/app/app/standings/page.tsx
+++ b/frontend/app/app/standings/page.tsx
@@ -1,0 +1,98 @@
+import React from "react"
+import Link from "next/link"
+import BackButton from "@/app/components/back-button"
+import {getConfigWithAuthHeader} from "@/app/api/client-config"
+import {ListMatchesFilterTypeEnum, MatchApi, Standings, StandingsApi} from "@/client"
+import {PitchPerspective} from "@/app/components/atmosphere"
+import GroupTable from "@/app/components/standings/group-table"
+import ThirdPlacedTable from "@/app/components/standings/third-placed-table"
+import StandingsRefresher from "@/app/components/standings/standings-refresher"
+
+export const dynamic = "force-dynamic"
+
+function TableIcon({className}: {className?: string}): React.JSX.Element {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden>
+            <rect x="3" y="4" width="18" height="16" rx="2"/>
+            <path d="M3 9h18M3 14h18M9 4v16"/>
+        </svg>
+    )
+}
+
+export default async function StandingsPage(): Promise<React.JSX.Element> {
+    const config = await getConfigWithAuthHeader()
+    const [standings, liveMatches] = await Promise.all([
+        new StandingsApi(config).getStandings().catch((): Standings => ({groups: [], thirdPlaced: []})),
+        new MatchApi(config).listMatches({filterType: ListMatchesFilterTypeEnum.Live}).catch(() => []),
+    ])
+    const hasLiveMatch = liveMatches.length > 0
+
+    return (
+        <main className="relative min-h-svh bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-x-hidden">
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.08),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.05),transparent_60%)] dark:bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.15),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.10),transparent_60%)]"/>
+            <div className="pointer-events-none absolute inset-x-0 top-0 h-svh"><PitchPerspective/></div>
+
+            {hasLiveMatch && <StandingsRefresher/>}
+
+            <div className="relative w-full max-w-5xl mx-auto px-4 sm:px-6 py-6 space-y-8">
+                <header className="relative flex items-center justify-between gap-3">
+                    <BackButton/>
+                    <Link href="/" className="hidden sm:flex items-baseline font-black tracking-tight text-lg absolute left-1/2 -translate-x-1/2">
+                        <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">predicta</span>
+                        <span className="text-slate-900 dark:text-white">ball</span>
+                        <span className="ml-0.5 text-[10px] font-medium tracking-[0.2em] text-slate-500 dark:text-gray-400">.LIVE</span>
+                    </Link>
+                    <div className="w-10"/>
+                </header>
+
+                <div className="flex flex-col items-center text-center">
+                    <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500 via-cyan-400 to-teal-300 shadow-lg shadow-cyan-500/30">
+                        <TableIcon className="h-8 w-8 text-white"/>
+                    </div>
+                    <p className="mt-3 text-xs font-bold uppercase tracking-[0.25em] text-slate-500 dark:text-gray-400">Group Stage</p>
+                    <h1 className="mt-1 text-3xl font-black tracking-tight text-slate-900 dark:text-white">Standings</h1>
+                    <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-gray-400">
+                        Live group tables, updated as scores come in.
+                        {hasLiveMatch && (
+                            <span className="ml-1 inline-flex items-center gap-1 font-semibold text-rose-500">
+                                <span className="h-1.5 w-1.5 rounded-full bg-rose-500 animate-pulse"/>
+                                Live
+                            </span>
+                        )}
+                    </p>
+                </div>
+
+                {standings.groups.length === 0 ? (
+                    <div className="mx-auto max-w-md rounded-2xl bg-white border border-slate-200 dark:bg-white/5 dark:border-white/10 px-4 py-8 text-center text-sm text-slate-500 dark:text-gray-400">
+                        Standings will appear here once the group stage gets under way.
+                    </div>
+                ) : (
+                    <>
+                        <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            {standings.groups.map(g => (
+                                <GroupTable key={g.group} group={g.group} standings={g.standings}/>
+                            ))}
+                        </section>
+
+                        <section className="space-y-4">
+                            <div className="flex flex-col items-center text-center">
+                                <h2 className="text-2xl font-black tracking-tight text-slate-900 dark:text-white">Third-placed teams</h2>
+                                <p className="mt-1 max-w-md text-sm text-slate-500 dark:text-gray-400">
+                                    Ranked across all groups — the eight best third-placed teams join the round of 32.
+                                </p>
+                            </div>
+                            <div className="mx-auto max-w-2xl">
+                                <ThirdPlacedTable rows={standings.thirdPlaced}/>
+                            </div>
+                        </section>
+                    </>
+                )}
+
+                <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pb-8 text-xs text-slate-500 dark:text-gray-400">
+                    <span className="inline-flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-emerald-500"/>Qualifies</span>
+                    <span className="inline-flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-amber-500"/>Best-third contention</span>
+                </div>
+            </div>
+        </main>
+    )
+}

--- a/frontend/app/components/standings/group-table.tsx
+++ b/frontend/app/components/standings/group-table.tsx
@@ -1,0 +1,72 @@
+import React from "react"
+import {GroupStandingRow} from "@/client"
+import {FlagImage} from "@/app/components/predictions/flag-image"
+
+/**
+ * Background tint for a row based on where the team sits. Top two qualify for
+ * the knockouts directly; third place may still go through as a best third.
+ */
+function positionAccent(position: number): string {
+    if (position <= 2) return "bg-emerald-500/10 dark:bg-emerald-400/10"
+    if (position === 3) return "bg-amber-500/10 dark:bg-amber-400/10"
+    return ""
+}
+
+function positionDot(position: number): string {
+    if (position <= 2) return "bg-emerald-500"
+    if (position === 3) return "bg-amber-500"
+    return "bg-slate-300 dark:bg-white/20"
+}
+
+export default function GroupTable({group, standings}: {group: string; standings: GroupStandingRow[]}): React.JSX.Element {
+    return (
+        <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-xl shadow-slate-900/5 dark:shadow-cyan-500/5">
+            <div className="rounded-3xl bg-white/70 dark:bg-white/[0.03] backdrop-blur-sm overflow-hidden">
+                <div className="flex items-center gap-2 px-4 pt-4 pb-2">
+                    <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 via-cyan-400 to-teal-300 text-sm font-black text-white">
+                        {group}
+                    </span>
+                    <span className="text-sm font-bold text-slate-700 dark:text-gray-200">Group {group}</span>
+                </div>
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="text-[11px] uppercase tracking-wider text-slate-400 dark:text-gray-500">
+                            <th className="py-1.5 pl-4 pr-1 text-left font-semibold">#</th>
+                            <th className="py-1.5 px-1 text-left font-semibold">Team</th>
+                            <th className="py-1.5 px-1 text-center font-semibold w-7">P</th>
+                            <th className="py-1.5 px-1 text-center font-semibold w-7 hidden sm:table-cell">W</th>
+                            <th className="py-1.5 px-1 text-center font-semibold w-7 hidden sm:table-cell">D</th>
+                            <th className="py-1.5 px-1 text-center font-semibold w-7 hidden sm:table-cell">L</th>
+                            <th className="py-1.5 px-1 text-center font-semibold w-9">GD</th>
+                            <th className="py-1.5 pl-1 pr-4 text-center font-semibold w-9">Pts</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {standings.map(row => (
+                            <tr key={row.teamId} className={`border-t border-slate-900/5 dark:border-white/5 ${positionAccent(row.position)}`}>
+                                <td className="py-2 pl-4 pr-1">
+                                    <span className="flex items-center gap-1.5">
+                                        <span className={`h-1.5 w-1.5 rounded-full ${positionDot(row.position)}`}/>
+                                        <span className="text-xs font-semibold text-slate-500 dark:text-gray-400">{row.position}</span>
+                                    </span>
+                                </td>
+                                <td className="py-2 px-1">
+                                    <span className="flex items-center gap-2 min-w-0">
+                                        <FlagImage code={row.flagCode} name={row.teamName} size={22}/>
+                                        <span className="truncate font-semibold text-slate-800 dark:text-gray-100">{row.teamName}</span>
+                                    </span>
+                                </td>
+                                <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300">{row.played}</td>
+                                <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.won}</td>
+                                <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.drawn}</td>
+                                <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.lost}</td>
+                                <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300">{row.goalDifference > 0 ? `+${row.goalDifference}` : row.goalDifference}</td>
+                                <td className="py-2 pl-1 pr-4 text-center tabular-nums font-black text-slate-900 dark:text-white">{row.points}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    )
+}

--- a/frontend/app/components/standings/standings-refresher.tsx
+++ b/frontend/app/components/standings/standings-refresher.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import {useEffect} from "react"
+import {useRouter} from "next/navigation"
+
+const REFRESH_INTERVAL_MS = 60_000
+
+/**
+ * Re-fetches the (server-rendered) standings on an interval so the tables stay
+ * live while matches are in play. Only mounted when there is a live match.
+ */
+export default function StandingsRefresher(): null {
+    const router = useRouter()
+    useEffect(() => {
+        const id = setInterval(() => router.refresh(), REFRESH_INTERVAL_MS)
+        return () => clearInterval(id)
+    }, [router])
+    return null
+}

--- a/frontend/app/components/standings/third-placed-table.tsx
+++ b/frontend/app/components/standings/third-placed-table.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import {GroupStandingRow} from "@/client"
+import {FlagImage} from "@/app/components/predictions/flag-image"
+
+// The eight best third-placed teams advance to the round of 32.
+const QUALIFYING_THIRD_PLACED = 8
+
+export default function ThirdPlacedTable({rows}: {rows: GroupStandingRow[]}): React.JSX.Element {
+    if (rows.length === 0) {
+        return (
+            <div className="rounded-2xl bg-white border border-slate-200 dark:bg-white/5 dark:border-white/10 px-4 py-8 text-center text-sm text-slate-500 dark:text-gray-400">
+                No standings yet — check back once group matches have been played.
+            </div>
+        )
+    }
+    return (
+        <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-xl shadow-slate-900/5 dark:shadow-cyan-500/5">
+            <div className="rounded-3xl bg-white/70 dark:bg-white/[0.03] backdrop-blur-sm overflow-hidden">
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="text-[11px] uppercase tracking-wider text-slate-400 dark:text-gray-500">
+                            <th className="py-2 pl-4 pr-1 text-left font-semibold">#</th>
+                            <th className="py-2 px-1 text-left font-semibold">Team</th>
+                            <th className="py-2 px-1 text-center font-semibold w-8">Grp</th>
+                            <th className="py-2 px-1 text-center font-semibold w-7">P</th>
+                            <th className="py-2 px-1 text-center font-semibold w-9">GD</th>
+                            <th className="py-2 pl-1 pr-4 text-center font-semibold w-9">Pts</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.map(row => {
+                            const qualifying = row.position <= QUALIFYING_THIRD_PLACED
+                            return (
+                                <tr key={row.teamId} className={`border-t border-slate-900/5 dark:border-white/5 ${qualifying ? "bg-emerald-500/10 dark:bg-emerald-400/10" : ""}`}>
+                                    <td className="py-2 pl-4 pr-1">
+                                        <span className="flex items-center gap-1.5">
+                                            <span className={`h-1.5 w-1.5 rounded-full ${qualifying ? "bg-emerald-500" : "bg-slate-300 dark:bg-white/20"}`}/>
+                                            <span className="text-xs font-semibold text-slate-500 dark:text-gray-400">{row.position}</span>
+                                        </span>
+                                    </td>
+                                    <td className="py-2 px-1">
+                                        <span className="flex items-center gap-2 min-w-0">
+                                            <FlagImage code={row.flagCode} name={row.teamName} size={22}/>
+                                            <span className="truncate font-semibold text-slate-800 dark:text-gray-100">{row.teamName}</span>
+                                        </span>
+                                    </td>
+                                    <td className="py-2 px-1 text-center font-bold text-slate-500 dark:text-gray-400">{row.group}</td>
+                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300">{row.played}</td>
+                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300">{row.goalDifference > 0 ? `+${row.goalDifference}` : row.goalDifference}</td>
+                                    <td className="py-2 pl-1 pr-4 text-center tabular-nums font-black text-slate-900 dark:text-white">{row.points}</td>
+                                </tr>
+                            )
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    )
+}

--- a/lambdas/src/main/kotlin/scorcerer/server/Server.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/Server.kt
@@ -22,6 +22,7 @@ import scorcerer.server.resources.leagueRoutes
 import scorcerer.server.resources.matchRoutes
 import scorcerer.server.resources.miscRoutes
 import scorcerer.server.resources.predictionRoutes
+import scorcerer.server.resources.standingsRoutes
 import scorcerer.server.resources.teamRoutes
 import scorcerer.server.resources.tournamentRoutes
 import scorcerer.server.resources.userRoutes
@@ -58,6 +59,7 @@ private val allRoutes = routes(
     leagueRoutes(requestContext, leaderboardService),
     matchRoutes(requestContext, leaderboardService, tournamentStateService),
     predictionRoutes(requestContext),
+    standingsRoutes(),
     teamRoutes(requestContext),
     tournamentRoutes(tournamentStateService),
     userRoutes(requestContext, leaderboardService, authProvider),

--- a/lambdas/src/main/kotlin/scorcerer/server/db/tables/TeamTable.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/db/tables/TeamTable.kt
@@ -7,5 +7,6 @@ object TeamTable : Table("team") {
     val name = varchar("name", 30).uniqueIndex()
     val flagCode = varchar("flag_code", 100)
     val ranking = integer("ranking").nullable()
+    val group = varchar("group", 1).nullable()
     override val primaryKey = PrimaryKey(id)
 }

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/Standings.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/Standings.kt
@@ -1,0 +1,203 @@
+package scorcerer.server.resources
+
+import org.http4k.core.Method
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.routing.bind
+import org.http4k.routing.routes
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.openapitools.server.models.GroupStanding
+import org.openapitools.server.models.GroupStandingRow
+import org.openapitools.server.models.Standings
+import scorcerer.server.db.tables.MatchRound
+import scorcerer.server.db.tables.MatchTable
+import scorcerer.server.db.tables.TeamTable
+import scorcerer.server.toJson
+import scorcerer.utils.toTitleCase
+
+/** A team that has been assigned to a group. */
+internal data class StandingsTeam(
+    val teamId: Int,
+    val teamName: String,
+    val flagCode: String,
+    val group: String,
+    val ranking: Int?,
+)
+
+/** A group-stage match with a (current) score — either live or completed. */
+internal data class PlayedMatch(
+    val homeTeamId: Int,
+    val awayTeamId: Int,
+    val homeScore: Int,
+    val awayScore: Int,
+)
+
+/** Mutable accumulator for a single team's group-stage record. */
+private class Accumulator(val team: StandingsTeam) {
+    var played = 0
+    var won = 0
+    var drawn = 0
+    var lost = 0
+    var goalsFor = 0
+    var goalsAgainst = 0
+    val points get() = won * 3 + drawn
+    val goalDifference get() = goalsFor - goalsAgainst
+}
+
+/** Head-to-head record of one team against a specific set of tied teams. */
+private data class HeadToHead(val points: Int, val goalDifference: Int, val goalsFor: Int)
+
+fun standingsRoutes() = routes(
+    "/standings" bind Method.GET to {
+        val (teams, matches) = transaction {
+            val teams = TeamTable.selectAll()
+                .where { TeamTable.group.isNotNull() }
+                .map {
+                    StandingsTeam(
+                        it[TeamTable.id],
+                        it[TeamTable.name].toTitleCase(),
+                        it[TeamTable.flagCode],
+                        it[TeamTable.group]!!,
+                        it[TeamTable.ranking],
+                    )
+                }
+            val teamIds = teams.map { it.teamId }.toSet()
+            val matches = MatchTable.selectAll()
+                .where {
+                    (MatchTable.round eq MatchRound.GROUP_STAGE) and
+                        MatchTable.homeScore.isNotNull() and
+                        MatchTable.awayScore.isNotNull()
+                }
+                .map { PlayedMatch(it[MatchTable.homeTeamId], it[MatchTable.awayTeamId], it[MatchTable.homeScore]!!, it[MatchTable.awayScore]!!) }
+                .filter { it.homeTeamId in teamIds && it.awayTeamId in teamIds }
+            teams to matches
+        }
+        Response(Status.OK).body(computeStandings(teams, matches).toJson())
+    },
+)
+
+/**
+ * Build group-stage standings from the teams and the matches played (or in
+ * progress) so far. Tie-breakers, in order:
+ *   1. Most points in head-to-head matches among the tied teams
+ *   2. Superior goal difference in those head-to-head matches
+ *   3. Most goals scored in those head-to-head matches
+ *   4. Superior goal difference across all group matches
+ *   5. Most goals scored across all group matches
+ *   6. Highest FIFA ranking (lowest ranking number)
+ * (The conduct-score criterion is omitted as we don't track cards.)
+ */
+internal fun computeStandings(teams: List<StandingsTeam>, matches: List<PlayedMatch>): Standings {
+    val accumulators = teams.associate { it.teamId to Accumulator(it) }
+
+    matches.forEach { match ->
+        val home = accumulators[match.homeTeamId] ?: return@forEach
+        val away = accumulators[match.awayTeamId] ?: return@forEach
+        home.played++
+        away.played++
+        home.goalsFor += match.homeScore
+        home.goalsAgainst += match.awayScore
+        away.goalsFor += match.awayScore
+        away.goalsAgainst += match.homeScore
+        when {
+            match.homeScore > match.awayScore -> {
+                home.won++
+                away.lost++
+            }
+            match.homeScore < match.awayScore -> {
+                away.won++
+                home.lost++
+            }
+            else -> {
+                home.drawn++
+                away.drawn++
+            }
+        }
+    }
+
+    val groups = accumulators.values
+        .groupBy { it.team.group }
+        .toSortedMap()
+        .map { (group, groupAccumulators) ->
+            val ranked = rankGroup(groupAccumulators, matches)
+            GroupStanding(group, ranked.mapIndexed { index, acc -> acc.toRow(index + 1) })
+        }
+
+    // Third-placed teams from every group, ranked against each other. Different
+    // groups have no head-to-head, so only the overall criteria apply.
+    val thirdPlaced = groups
+        .mapNotNull { it.standings.getOrNull(2) }
+        .sortedWith(
+            compareByDescending<GroupStandingRow> { it.points }
+                .thenByDescending { it.goalDifference }
+                .thenByDescending { it.goalsFor }
+                .thenBy { teams.first { t -> t.teamId.toString() == it.teamId }.ranking ?: Int.MAX_VALUE },
+        )
+        .mapIndexed { index, row -> row.copy(position = index + 1) }
+
+    return Standings(groups, thirdPlaced)
+}
+
+private fun rankGroup(accumulators: List<Accumulator>, matches: List<PlayedMatch>): List<Accumulator> =
+    accumulators
+        .sortedByDescending { it.points }
+        .groupBy { it.points }
+        .flatMap { (_, cluster) -> rankCluster(cluster, matches) }
+
+/** Order teams that are level on points using the head-to-head and overall tie-breakers. */
+private fun rankCluster(cluster: List<Accumulator>, matches: List<PlayedMatch>): List<Accumulator> {
+    if (cluster.size == 1) return cluster
+    val tiedIds = cluster.map { it.team.teamId }.toSet()
+    val headToHead = cluster.associate { it.team.teamId to headToHead(it.team.teamId, tiedIds, matches) }
+    return cluster.sortedWith(
+        compareByDescending<Accumulator> { headToHead.getValue(it.team.teamId).points }
+            .thenByDescending { headToHead.getValue(it.team.teamId).goalDifference }
+            .thenByDescending { headToHead.getValue(it.team.teamId).goalsFor }
+            .thenByDescending { it.goalDifference }
+            .thenByDescending { it.goalsFor }
+            .thenBy { it.team.ranking ?: Int.MAX_VALUE },
+    )
+}
+
+private fun headToHead(teamId: Int, tiedIds: Set<Int>, matches: List<PlayedMatch>): HeadToHead {
+    var points = 0
+    var goalsFor = 0
+    var goalsAgainst = 0
+    matches
+        .filter { it.homeTeamId in tiedIds && it.awayTeamId in tiedIds && (it.homeTeamId == teamId || it.awayTeamId == teamId) }
+        .forEach { match ->
+            val (scored, conceded) = if (match.homeTeamId == teamId) {
+                match.homeScore to match.awayScore
+            } else {
+                match.awayScore to match.homeScore
+            }
+            goalsFor += scored
+            goalsAgainst += conceded
+            points += when {
+                scored > conceded -> 3
+                scored == conceded -> 1
+                else -> 0
+            }
+        }
+    return HeadToHead(points, goalsFor - goalsAgainst, goalsFor)
+}
+
+private fun Accumulator.toRow(position: Int) = GroupStandingRow(
+    position = position,
+    teamId = team.teamId.toString(),
+    teamName = team.teamName,
+    flagCode = team.flagCode,
+    group = team.group,
+    played = played,
+    won = won,
+    drawn = drawn,
+    lost = lost,
+    goalsFor = goalsFor,
+    goalsAgainst = goalsAgainst,
+    goalDifference = goalDifference,
+    points = points,
+)

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/Team.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/Team.kt
@@ -26,7 +26,7 @@ fun teamRoutes(contexts: RequestContexts) = routes(
     "/team" bind Method.GET to {
         val teams = transaction {
             TeamTable.selectAll().map { row ->
-                Team(row[TeamTable.id].toString(), row[TeamTable.name].toTitleCase(), row[TeamTable.flagCode])
+                Team(row[TeamTable.id].toString(), row[TeamTable.name].toTitleCase(), row[TeamTable.flagCode], row[TeamTable.group])
             }
         }
         Response(Status.OK).body(teams.toJson())
@@ -48,7 +48,7 @@ fun teamRoutes(contexts: RequestContexts) = routes(
         val teamId = req.path("teamId")!!
         val team = transaction {
             TeamTable.selectAll().where { TeamTable.id eq teamId.toInt() }.firstOrNull()
-                ?.let { row -> Team(row[TeamTable.id].toString(), row[TeamTable.name].toTitleCase(), row[TeamTable.flagCode]) }
+                ?.let { row -> Team(row[TeamTable.id].toString(), row[TeamTable.name].toTitleCase(), row[TeamTable.flagCode], row[TeamTable.group]) }
                 ?: throw ApiResponseError(Response(Status.BAD_REQUEST).body("Team does not exist"))
         }
         Response(Status.OK).body(team.toJson())
@@ -57,7 +57,7 @@ fun teamRoutes(contexts: RequestContexts) = routes(
         val teamName = req.path("teamName")!!
         val team = transaction {
             TeamTable.selectAll().where { TeamTable.name eq teamName.lowercase() }.firstOrNull()
-                ?.let { row -> Team(row[TeamTable.id].toString(), row[TeamTable.name].toTitleCase(), row[TeamTable.flagCode]) }
+                ?.let { row -> Team(row[TeamTable.id].toString(), row[TeamTable.name].toTitleCase(), row[TeamTable.flagCode], row[TeamTable.group]) }
                 ?: throw ApiResponseError(Response(Status.BAD_REQUEST).body("Team does not exist"))
         }
         Response(Status.OK).body(team.toJson())

--- a/lambdas/src/main/resources/db/migration/V12__add_team_group.sql
+++ b/lambdas/src/main/resources/db/migration/V12__add_team_group.sql
@@ -1,0 +1,21 @@
+-- Assign each of the 48 teams to its World Cup 2026 group (A-L).
+-- "group" is a reserved word in Postgres, so it is always quoted.
+-- Groups are derived from the seeded group-stage fixtures: the four teams that
+-- play a round-robin against each other form a group. Letters follow the host
+-- anchors (Mexico=A, Canada=B, USA=D) and the final-matchday schedule blocks
+-- (day 14 -> A/B/C, day 15 -> D/E/F, day 16 -> G/H/I, day 17 -> J/K/L).
+
+ALTER TABLE team ADD COLUMN IF NOT EXISTS "group" VARCHAR(1);
+
+UPDATE team SET "group" = 'A' WHERE name IN ('mexico', 'south africa', 'south korea', 'czech republic');
+UPDATE team SET "group" = 'B' WHERE name IN ('canada', 'switzerland', 'bosnia and herzegovina', 'qatar');
+UPDATE team SET "group" = 'C' WHERE name IN ('brazil', 'morocco', 'haiti', 'scotland');
+UPDATE team SET "group" = 'D' WHERE name IN ('united states', 'paraguay', 'australia', 'turkey');
+UPDATE team SET "group" = 'E' WHERE name IN ('germany', 'curacao', 'ivory coast', 'ecuador');
+UPDATE team SET "group" = 'F' WHERE name IN ('netherlands', 'japan', 'sweden', 'tunisia');
+UPDATE team SET "group" = 'G' WHERE name IN ('spain', 'cape verde', 'saudi arabia', 'uruguay');
+UPDATE team SET "group" = 'H' WHERE name IN ('belgium', 'egypt', 'iran', 'new zealand');
+UPDATE team SET "group" = 'I' WHERE name IN ('france', 'senegal', 'norway', 'iraq');
+UPDATE team SET "group" = 'J' WHERE name IN ('argentina', 'algeria', 'austria', 'jordan');
+UPDATE team SET "group" = 'K' WHERE name IN ('portugal', 'dr congo', 'uzbekistan', 'colombia');
+UPDATE team SET "group" = 'L' WHERE name IN ('england', 'croatia', 'ghana', 'panama');

--- a/lambdas/src/main/resources/db/migration/V12__add_team_group.sql
+++ b/lambdas/src/main/resources/db/migration/V12__add_team_group.sql
@@ -1,9 +1,6 @@
 -- Assign each of the 48 teams to its World Cup 2026 group (A-L).
 -- "group" is a reserved word in Postgres, so it is always quoted.
--- Groups are derived from the seeded group-stage fixtures: the four teams that
--- play a round-robin against each other form a group. Letters follow the host
--- anchors (Mexico=A, Canada=B, USA=D) and the final-matchday schedule blocks
--- (day 14 -> A/B/C, day 15 -> D/E/F, day 16 -> G/H/I, day 17 -> J/K/L).
+-- Group letters match the official FIFA World Cup 2026 draw.
 
 ALTER TABLE team ADD COLUMN IF NOT EXISTS "group" VARCHAR(1);
 
@@ -13,8 +10,8 @@ UPDATE team SET "group" = 'C' WHERE name IN ('brazil', 'morocco', 'haiti', 'scot
 UPDATE team SET "group" = 'D' WHERE name IN ('united states', 'paraguay', 'australia', 'turkey');
 UPDATE team SET "group" = 'E' WHERE name IN ('germany', 'curacao', 'ivory coast', 'ecuador');
 UPDATE team SET "group" = 'F' WHERE name IN ('netherlands', 'japan', 'sweden', 'tunisia');
-UPDATE team SET "group" = 'G' WHERE name IN ('spain', 'cape verde', 'saudi arabia', 'uruguay');
-UPDATE team SET "group" = 'H' WHERE name IN ('belgium', 'egypt', 'iran', 'new zealand');
+UPDATE team SET "group" = 'G' WHERE name IN ('belgium', 'egypt', 'iran', 'new zealand');
+UPDATE team SET "group" = 'H' WHERE name IN ('spain', 'cape verde', 'saudi arabia', 'uruguay');
 UPDATE team SET "group" = 'I' WHERE name IN ('france', 'senegal', 'norway', 'iraq');
 UPDATE team SET "group" = 'J' WHERE name IN ('argentina', 'algeria', 'austria', 'jordan');
 UPDATE team SET "group" = 'K' WHERE name IN ('portugal', 'dr congo', 'uzbekistan', 'colombia');

--- a/lambdas/src/test/kotlin/scorcerer/Utils.kt
+++ b/lambdas/src/test/kotlin/scorcerer/Utils.kt
@@ -36,6 +36,8 @@ fun givenMatchExists(
     matchDatetime: OffsetDateTime = OffsetDateTime.now(),
     matchState: Match.State = Match.State.UPCOMING,
     matchDay: Int = 1,
+    homeScore: Int? = null,
+    awayScore: Int? = null,
 ): String {
     return (
         transaction {
@@ -47,17 +49,21 @@ fun givenMatchExists(
                 it[this.venue] = "Test Venue"
                 it[this.matchDay] = matchDay
                 it[this.round] = MatchRound.GROUP_STAGE
+                if (homeScore != null) it[this.homeScore] = homeScore
+                if (awayScore != null) it[this.awayScore] = awayScore
             }
         } get MatchTable.id
         ).toString()
 }
 
-fun givenTeamExists(teamName: String): String {
+fun givenTeamExists(teamName: String, group: String? = null, ranking: Int? = null): String {
     return (
         transaction {
             TeamTable.insert {
                 it[this.name] = teamName
                 it[this.flagCode] = ""
+                if (group != null) it[this.group] = group
+                if (ranking != null) it[this.ranking] = ranking
             }
         } get TeamTable.id
         ).toString()

--- a/lambdas/src/test/kotlin/scorcerer/resources/StandingsTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/resources/StandingsTest.kt
@@ -1,0 +1,143 @@
+package scorcerer.resources
+
+import io.kotest.matchers.shouldBe
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.RequestContexts
+import org.http4k.core.Status
+import org.junit.jupiter.api.Test
+import org.openapitools.server.models.Match
+import org.openapitools.server.models.Standings
+import scorcerer.DatabaseTest
+import scorcerer.givenMatchExists
+import scorcerer.givenTeamExists
+import scorcerer.server.fromJson
+import scorcerer.server.resources.PlayedMatch
+import scorcerer.server.resources.StandingsTeam
+import scorcerer.server.resources.computeStandings
+import scorcerer.server.resources.standingsRoutes
+
+class StandingsComputationTest {
+    private fun team(id: Int, group: String = "A", ranking: Int? = null) =
+        StandingsTeam(id, "Team $id", "fl", group, ranking)
+
+    private fun match(home: Int, away: Int, homeScore: Int, awayScore: Int) =
+        PlayedMatch(home, away, homeScore, awayScore)
+
+    @Test
+    fun ordersByPointsThenGoalDifference() {
+        val teams = listOf(team(1), team(2), team(3), team(4))
+        // 1 beats 2 and 3; 3 beats 4; 2 beats 4 with a big margin.
+        // Points: team1=6, team2=3, team3=3, team4=0.
+        val matches = listOf(
+            match(1, 2, 3, 0),
+            match(1, 3, 1, 0),
+            match(4, 3, 0, 2),
+            match(2, 4, 5, 0),
+        )
+        val group = computeStandings(teams, matches).groups.single { it.group == "A" }.standings
+
+        group.map { it.teamId } shouldBe listOf("1", "2", "3", "4")
+        group.map { it.position } shouldBe listOf(1, 2, 3, 4)
+        group[0].points shouldBe 6
+        // team2 and team3 both on 3 points; team2 has GD +2 (5-3), team3 has GD +1 (2-2) -> overall GD breaks it
+        group[1].teamId shouldBe "2"
+        group[2].teamId shouldBe "3"
+    }
+
+    @Test
+    fun headToHeadBeatsOverallGoalDifference() {
+        // team1 and team2 both end on 6 points. team2 has a much better overall GD,
+        // but team1 won the head-to-head, so team1 must rank above team2.
+        val teams = listOf(team(1), team(2), team(3), team(4))
+        // team1 beats team2 head-to-head and beats team3.
+        // team2 thrashes team4 (huge GD) and beats team3.
+        // team1: 6 pts, GD +2. team2: 6 pts, GD +7. H2H: team1 won -> team1 first.
+        val matches = listOf(
+            match(1, 2, 1, 0),
+            match(1, 3, 1, 0),
+            match(2, 4, 7, 0),
+            match(2, 3, 1, 0),
+        )
+        val group = computeStandings(teams, matches).groups.single { it.group == "A" }.standings
+        group[0].teamId shouldBe "1"
+        group[1].teamId shouldBe "2"
+    }
+
+    @Test
+    fun fallsThroughToFifaRankingWhenAllElseEqual() {
+        // Two teams identical in every on-pitch metric (they drew each other and
+        // have identical records) -> FIFA ranking decides. Lower number = better.
+        val teams = listOf(team(1, ranking = 10), team(2, ranking = 5))
+        // A draw leaves equal points, equal h2h, equal GD and equal goals.
+        val matches = listOf(
+            match(1, 2, 1, 1),
+        )
+        val group = computeStandings(teams, matches).groups.single { it.group == "A" }.standings
+        group[0].teamId shouldBe "2" // ranking 5 beats ranking 10
+        group[1].teamId shouldBe "1"
+    }
+
+    @Test
+    fun thirdPlacedTableRanksThirdPlacedTeamsAcrossGroups() {
+        // Group A and Group B, each with 4 teams. We only care that the 3rd-placed
+        // team of each group is collected and ranked against each other.
+        val teams = listOf(
+            team(1, "A"),
+            team(2, "A"),
+            team(3, "A"),
+            team(4, "A"),
+            team(5, "B"),
+            team(6, "B"),
+            team(7, "B"),
+            team(8, "B"),
+        )
+        val matches = listOf(
+            // Group A: 1>2>3>4. Third place = team3 with 3 points.
+            match(1, 2, 1, 0), match(1, 3, 1, 0), match(1, 4, 1, 0),
+            match(2, 3, 1, 0), match(2, 4, 1, 0), match(3, 4, 1, 0),
+            // Group B: 5 wins all, 6 beats 7 and 8, and 8 beats 7 5-1. So the
+            // third-placed team is team8 (3 pts) with a much worse goal difference.
+            match(5, 6, 5, 0), match(5, 7, 5, 0), match(5, 8, 5, 0),
+            match(6, 7, 5, 0), match(6, 8, 5, 0), match(7, 8, 1, 5),
+        )
+        val standings = computeStandings(teams, matches)
+        val thirdPlaced = standings.thirdPlaced
+        thirdPlaced.map { it.teamId }.toSet() shouldBe setOf("3", "8")
+        // team3: 3 pts GD -1. team8: 3 pts GD -10 -> team3 ranks above team8.
+        thirdPlaced[0].teamId shouldBe "3"
+        thirdPlaced[0].position shouldBe 1
+        thirdPlaced[1].position shouldBe 2
+    }
+
+    @Test
+    fun groupsAreReturnedInAlphabeticalOrder() {
+        val teams = listOf(team(1, "C"), team(2, "A"), team(3, "B"))
+        val groups = computeStandings(teams, emptyList()).groups
+        groups.map { it.group } shouldBe listOf("A", "B", "C")
+    }
+}
+
+class StandingsRouteTest : DatabaseTest() {
+    private val contexts = RequestContexts()
+    private val handler = testHandler(contexts, standingsRoutes())
+
+    @Test
+    fun returnsStandingsForGroupsWithScoredMatches() {
+        val home = givenTeamExists("england", "A")
+        val away = givenTeamExists("france", "A")
+        givenTeamExists("spain", "B")
+        givenMatchExists(home, away, matchState = Match.State.COMPLETED, homeScore = 2, awayScore = 1)
+
+        val response = handler(Request(Method.GET, "/standings"))
+        response.status shouldBe Status.OK
+        val standings: Standings = response.bodyString().fromJson()
+
+        val groupA = standings.groups.single { it.group == "A" }.standings
+        groupA[0].teamName shouldBe "England"
+        groupA[0].points shouldBe 3
+        groupA[0].played shouldBe 1
+        groupA[1].teamName shouldBe "France"
+        groupA[1].points shouldBe 0
+    }
+}


### PR DESCRIPTION
Assign each team to its World Cup 2026 group (A-L) and add a standings
feature showing live group tables plus a best-third-placed ranking.

Backend:
- V12 migration adds a quoted `group` column to team and populates all 48
  teams (groups derived from the seeded fixtures; hosts anchor A/B/D).
- New GET /standings endpoint computing per-group tables as they stand,
  including live scores, with the full FIFA tie-breaker chain (head-to-head
  points/GD/goals among tied teams, then overall GD/goals, then FIFA
  ranking; conduct score omitted as we don't track cards).
- Third-placed teams ranked across groups by points/GD/goals/ranking.
- Expose `group` on the team API model.

Frontend:
- New /app/standings page rendering 12 group tables and the third-placed
  table, with qualification highlighting and a live auto-refresh while a
  match is in play.
- Link to standings from the home Matches section.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FcdS8RrgRc1VM3yp95npmr