### PR TITLE
Clean up standings venue globe: zoom in, drop country fills, smaller flags

### DIFF
--- a/frontend/app/components/flags/group-venue-globe.tsx
+++ b/frontend/app/components/flags/group-venue-globe.tsx
@@ -6,7 +6,7 @@ import {Html, OrbitControls} from "@react-three/drei"
 import * as THREE from "three"
 import {COUNTRY_COORDS} from "./country-coords"
 import {resolveStadium, Stadium} from "./stadium-coords"
-import {GLOBE_RADIUS, latLngToVec3, buildContinentGeometry, buildCountryFillGeometry, hasCountryFill} from "./globe-utils"
+import {GLOBE_RADIUS, latLngToVec3, buildContinentGeometry} from "./globe-utils"
 
 // One fixture in a group, reduced to what the globe needs to plot it.
 export type GroupMatch = {
@@ -17,21 +17,16 @@ export type GroupMatch = {
     venue: string
 }
 
-// Extruded country highlight: a base just off the globe up to a raised top, so
-// the nations taking part in the group light up and stand proud of the surface.
-const COUNTRY_FILL_BASE = GLOBE_RADIUS + 0.005
-const COUNTRY_FILL_HEIGHT = 0.05
-const COUNTRY_FILL_TOP = COUNTRY_FILL_BASE + COUNTRY_FILL_HEIGHT
+// Venue markers rest just off the globe surface.
 const STADIUM_BASE_OFFSET = 0.01
-// Maps a World Cup host nation to the team code we extrude it under, so a venue
-// rests on the raised land when its host country is one of the group's teams.
-const HOST_NATION_CODE: Record<string, string> = {usa: "us", can: "ca", mex: "mx"}
 
 const CAMERA_FOV = 42
-const CAMERA_FIT_MARGIN = 1.3
-const CAMERA_MIN_DISTANCE = 2.6
-// The pills float above the markers; frame to keep that whole region in shot.
-const FOCUS_OUTER_RADIUS = GLOBE_RADIUS + 0.4
+// Tight framing: zoom right in on the venues so they fill the frame, leaving
+// only a little breathing room around the cluster.
+const CAMERA_FIT_MARGIN = 1.06
+const CAMERA_MIN_DISTANCE = 2.15
+// The pills float just above the markers; frame to keep them in shot.
+const FOCUS_OUTER_RADIUS = GLOBE_RADIUS + 0.2
 
 // A unique venue plus every group fixture being played there.
 type VenuePlot = {
@@ -40,17 +35,10 @@ type VenuePlot = {
     matchups: {homeFlagCode: string; awayFlagCode: string; homeTeam: string; awayTeam: string}[]
 }
 
-// Where a venue's marker sits: on the raised country top when its host nation is
-// one of the playing teams (and thus extruded), otherwise just off the surface.
-function venueRadius(stadium: Stadium, countryCodes: string[]): number {
-    const hostCode = HOST_NATION_CODE[stadium.country]
-    return countryCodes.includes(hostCode) ? COUNTRY_FILL_TOP : GLOBE_RADIUS + STADIUM_BASE_OFFSET
-}
-
 // Collapses the group's fixtures down to the distinct venues hosting them, each
 // carrying the matchups played there. Fixtures whose venue we can't place are
 // dropped from the globe (they still appear in the table).
-function resolveVenues(matches: GroupMatch[], countryCodes: string[]): VenuePlot[] {
+function resolveVenues(matches: GroupMatch[]): VenuePlot[] {
     const byCity = new Map<string, VenuePlot>()
     for (const m of matches) {
         const stadium = resolveStadium(m.venue)
@@ -69,7 +57,7 @@ function resolveVenues(matches: GroupMatch[], countryCodes: string[]): VenuePlot
         const dir = latLngToVec3(stadium.lat, stadium.lng, 1)
         byCity.set(stadium.city, {
             stadium,
-            position: dir.multiplyScalar(venueRadius(stadium, countryCodes)),
+            position: dir.multiplyScalar(GLOBE_RADIUS + STADIUM_BASE_OFFSET),
             matchups: [matchup],
         })
     }
@@ -111,47 +99,23 @@ function Continents() {
     )
 }
 
-// Fills a playing country's landmass with a highlight extruded slightly off the
-// globe, so each nation in the group lights up on the surface.
-function CountryFill({code, color}: {code: string; color: string}) {
-    const geometry = useMemo(
-        () => buildCountryFillGeometry(code, COUNTRY_FILL_BASE, COUNTRY_FILL_HEIGHT),
-        [code],
-    )
-    if (!geometry) return null
-    return (
-        <mesh geometry={geometry}>
-            <meshStandardMaterial
-                color={color}
-                emissive={color}
-                emissiveIntensity={0.25}
-                roughness={0.5}
-                metalness={0.1}
-                transparent
-                opacity={0.8}
-                side={THREE.DoubleSide}
-            />
-        </mesh>
-    )
-}
-
 const PILL_LIFT = 0.16
 
 // A small flag pill — "home v away" — sitting just above a venue marker. When a
 // venue hosts more than one group fixture they stack.
 function VenuePill({matchups}: {matchups: VenuePlot["matchups"]}) {
     return (
-        <div className="pointer-events-none flex flex-col items-center gap-1" style={{transform: "translate(-50%, -100%)"}}>
+        <div className="pointer-events-none flex flex-col items-center gap-0.5" style={{transform: "translate(-50%, -100%)"}}>
             {matchups.map((m, i) => (
                 <span
                     key={`${m.homeFlagCode}-${m.awayFlagCode}-${i}`}
-                    className="inline-flex items-center gap-1 rounded-full bg-white/85 border border-slate-200 dark:bg-black/55 dark:border-white/10 px-1.5 py-0.5 shadow-sm backdrop-blur whitespace-nowrap"
+                    className="inline-flex items-center gap-0.5 rounded-full bg-white/85 border border-slate-200 dark:bg-black/55 dark:border-white/10 px-1 py-0.5 shadow-sm backdrop-blur whitespace-nowrap"
                 >
                     {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={`https://flagcdn.com/w40/${m.homeFlagCode}.png`} alt={m.homeTeam} className="h-3.5 w-3.5 rounded-full object-cover ring-1 ring-slate-900/15 dark:ring-white/20"/>
-                    <span className="text-[9px] font-bold uppercase text-slate-400 dark:text-gray-500">v</span>
+                    <img src={`https://flagcdn.com/w40/${m.homeFlagCode}.png`} alt={m.homeTeam} className="h-2.5 w-2.5 rounded-full object-cover ring-1 ring-slate-900/15 dark:ring-white/20"/>
+                    <span className="text-[7px] font-bold uppercase text-slate-400 dark:text-gray-500">v</span>
                     {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={`https://flagcdn.com/w40/${m.awayFlagCode}.png`} alt={m.awayTeam} className="h-3.5 w-3.5 rounded-full object-cover ring-1 ring-slate-900/15 dark:ring-white/20"/>
+                    <img src={`https://flagcdn.com/w40/${m.awayFlagCode}.png`} alt={m.awayTeam} className="h-2.5 w-2.5 rounded-full object-cover ring-1 ring-slate-900/15 dark:ring-white/20"/>
                 </span>
             ))}
         </div>
@@ -200,16 +164,13 @@ function CameraRig({position}: {position: [number, number, number]}) {
 }
 
 function Scene({matches, enableControls}: {matches: GroupMatch[]; enableControls: boolean}) {
-    const {countryCodes, venues, cameraPos} = useMemo(() => {
-        const codes = uniqueCountryCodes(matches)
-        const plots = resolveVenues(matches, codes)
+    const {venues, cameraPos} = useMemo(() => {
+        const plots = resolveVenues(matches)
         const focusDirs = plots.length > 0
             ? plots.map(p => p.position.clone())
-            : codes.map(c => COUNTRY_COORDS[c]).filter(Boolean).map(c => latLngToVec3(c[0], c[1], 1))
-        return {countryCodes: codes, venues: plots, cameraPos: framingPosition(focusDirs)}
+            : uniqueCountryCodes(matches).map(c => COUNTRY_COORDS[c]).filter(Boolean).map(c => latLngToVec3(c[0], c[1], 1))
+        return {venues: plots, cameraPos: framingPosition(focusDirs)}
     }, [matches])
-
-    const fillCodes = useMemo(() => countryCodes.filter(hasCountryFill), [countryCodes])
 
     return (
         <>
@@ -223,7 +184,6 @@ function Scene({matches, enableControls}: {matches: GroupMatch[]; enableControls
                 <meshBasicMaterial color="#22d3ee" wireframe transparent opacity={0.08}/>
             </mesh>
             <Continents/>
-            {fillCodes.map(code => <CountryFill key={code} code={code} color="#67e8f9"/>)}
             {venues.map(plot => <VenueMarker key={plot.stadium.city} plot={plot}/>)}
             {enableControls && (
                 <OrbitControls enableZoom={false} enablePan={false} rotateSpeed={0.5} enableDamping dampingFactor={0.08}/>


### PR DESCRIPTION
Tightens the Group venues globe on the standings page into a clean, venue-focused view based on feedback from the attached screenshot.

## Changes
- **Zoom in much further** — lowered the camera fit margin (`1.3 → 1.06`) and min distance (`2.6 → 2.15`) so the venue cluster fills the frame instead of floating in a wide world view.
- **No coloured country borders** — removed the cyan `CountryFill` extruded highlights entirely. The globe now shows only the continent outlines and venue markers.
- **Smaller flag pills** — shrank the matchup flags (`h-3.5 w-3.5 → h-2.5 w-2.5`) and tightened padding/gaps so the pills no longer overlap and crowd the markers.

Venue marker placement is simplified accordingly (markers now always rest just off the surface, since there's no longer a raised country fill to sit on). The country-fill geometry helpers remain in `globe-utils.ts` as they're still used by `focused-globe.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLMv1TNXvQJYm2mk9So2kB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLMv1TNXvQJYm2mk9So2kB)_