### PR TITLE
Zoom the standings venue map to the group's stadiums and link to match pages

### DIFF
--- a/frontend/app/app/standings/page.tsx
+++ b/frontend/app/app/standings/page.tsx
@@ -28,13 +28,19 @@ function bucketMatchesByGroup(groups: Standings["groups"], matches: Match[]): Re
         if (!group) continue
         seen.add(m.matchId)
         ;(byGroup[group] ??= []).push({
+            matchId: m.matchId,
             homeTeam: m.homeTeam,
             homeFlagCode: m.homeTeamFlagCode,
             awayTeam: m.awayTeam,
             awayFlagCode: m.awayTeamFlagCode,
             venue: m.venue,
+            datetime: m.datetime,
+            state: m.state,
+            homeScore: m.homeScore,
+            awayScore: m.awayScore,
         })
     }
+    for (const group of Object.values(byGroup)) group.sort((a, b) => a.datetime.getTime() - b.datetime.getTime())
     return byGroup
 }
 

--- a/frontend/app/components/flags/group-venue-map.tsx
+++ b/frontend/app/components/flags/group-venue-map.tsx
@@ -1,26 +1,35 @@
 'use client'
 
 import React, {useMemo} from "react"
+import Link from "next/link"
 import type {MultiPolygon, Polygon, Position} from "geojson"
+import type {MatchStateEnum} from "@/client"
 import {resolveStadium, Stadium} from "./stadium-coords"
 import {getCountryGeometry} from "./globe-utils"
 
-// One fixture in a group, reduced to what the map needs to plot it.
+// One fixture in a group, reduced to what the map and match list need to plot
+// and describe it, and link it to its match page.
 export type GroupMatch = {
+    matchId: string
     homeTeam: string
     homeFlagCode: string
     awayTeam: string
     awayFlagCode: string
     venue: string
+    datetime: Date
+    state: MatchStateEnum
+    homeScore?: number
+    awayScore?: number
 }
 
 // The three World Cup 2026 host nations whose outlines we draw.
 const HOST_CODES = ["us", "ca", "mx"]
 
-// Fixed geographic window framing the hosts' populated regions. Canada's arctic
-// archipelago (and Alaska/Hawaii) fall outside this and are cropped by the SVG
-// viewport, keeping the map focused on where the venues actually are.
-const VIEW = {lngMin: -127, lngMax: -65, latMin: 13.5, latMax: 54}
+// Geographic window framing all host venues, used when a group's fixtures
+// don't resolve to any known stadium (so the map still shows something sane).
+const FULL_HOST_VIEW = {lngMin: -127, lngMax: -65, latMin: 13.5, latMax: 54}
+
+type View = typeof FULL_HOST_VIEW
 
 const VIEW_WIDTH = 1000
 const PADDING = 28
@@ -36,19 +45,44 @@ const SEPARATION_PADDING = 6
 const SEPARATION_ITERATIONS = 80
 const ANCHOR_SPRING = 0.05
 
+// Match pill sizing (the clickable "flag v flag" badge above each venue).
+const PILL_WIDTH = 112
+const PILL_HEIGHT = 34
+const PILL_GAP = 6
+
 // Standard Mercator, lng/lat in degrees -> planar units (x east, y north).
 function mercator(lng: number, lat: number): [number, number] {
     return [lng * Math.PI / 180, Math.log(Math.tan(Math.PI / 4 + (lat * Math.PI / 180) / 2))]
 }
 
-// Projects the fixed VIEW window into the padded viewBox at a single (true
-// Mercator) scale, so country shapes aren't distorted. Anything outside VIEW
-// projects outside the viewBox and is clipped.
-function makeProjection() {
-    const [xMin] = mercator(VIEW.lngMin, 0)
-    const [xMax] = mercator(VIEW.lngMax, 0)
-    const yTop = mercator(0, VIEW.latMax)[1]
-    const yBot = mercator(0, VIEW.latMin)[1]
+// Tight geographic window around the venues actually hosting this group's
+// fixtures, so the map zooms to where the action is rather than always
+// showing the full host footprint. Falls back to the full view when no
+// fixture resolves to a known stadium.
+function computeView(stadiums: Stadium[]): View {
+    if (stadiums.length === 0) return FULL_HOST_VIEW
+    let lngMin = Infinity, lngMax = -Infinity, latMin = Infinity, latMax = -Infinity
+    for (const s of stadiums) {
+        if (s.lng < lngMin) lngMin = s.lng
+        if (s.lng > lngMax) lngMax = s.lng
+        if (s.lat < latMin) latMin = s.lat
+        if (s.lat > latMax) latMax = s.lat
+    }
+    // Padding scales with the spread of venues, with a floor so a single-city
+    // group still shows enough surrounding context (and room for labels/pills).
+    const lngPad = Math.max((lngMax - lngMin) * 0.4, 5)
+    const latPad = Math.max((latMax - latMin) * 0.4, 4)
+    return {lngMin: lngMin - lngPad, lngMax: lngMax + lngPad, latMin: latMin - latPad, latMax: latMax + latPad}
+}
+
+// Projects a geographic window into the padded viewBox at a single (true
+// Mercator) scale, so country shapes aren't distorted. Anything outside the
+// view projects outside the viewBox and is clipped.
+function makeProjection(view: View) {
+    const [xMin] = mercator(view.lngMin, 0)
+    const [xMax] = mercator(view.lngMax, 0)
+    const yTop = mercator(0, view.latMax)[1]
+    const yBot = mercator(0, view.latMin)[1]
     const scale = (VIEW_WIDTH - 2 * PADDING) / (xMax - xMin)
     const height = (yTop - yBot) * scale + 2 * PADDING
     const project = (lng: number, lat: number): [number, number] => {
@@ -68,9 +102,9 @@ function ringToPath(ring: Position[], project: (lng: number, lat: number) => [nu
 }
 
 // Whether a ring is worth drawing: dropped if it lies entirely outside the view
-// window (e.g. Hawaii, far-north arctic islands) or wraps the antimeridian (the
-// Aleutians), which would otherwise streak a line across the map.
-function ringVisible(ring: Position[]): boolean {
+// window or wraps the antimeridian (the Aleutians), which would otherwise streak
+// a line across the map.
+function ringVisible(ring: Position[], view: View): boolean {
     let lngMin = Infinity, lngMax = -Infinity, latMin = Infinity, latMax = -Infinity
     for (const [lng, lat] of ring) {
         if (lng < lngMin) lngMin = lng
@@ -80,37 +114,54 @@ function ringVisible(ring: Position[]): boolean {
     }
     if (lngMax - lngMin > 180) return false
     const M = 6
-    if (lngMax < VIEW.lngMin - M || lngMin > VIEW.lngMax + M) return false
-    if (latMax < VIEW.latMin - M || latMin > VIEW.latMax + M) return false
+    if (lngMax < view.lngMin - M || lngMin > view.lngMax + M) return false
+    if (latMax < view.latMin - M || latMin > view.latMax + M) return false
     return true
 }
 
-function geometryToPath(geom: Polygon | MultiPolygon, project: (lng: number, lat: number) => [number, number]): string {
+function geometryToPath(geom: Polygon | MultiPolygon, project: (lng: number, lat: number) => [number, number], view: View): string {
     const polygons = geom.type === "Polygon" ? [geom.coordinates] : geom.coordinates
     return polygons
-        .map(poly => poly.filter(ringVisible).map(ring => ringToPath(ring, project)).join(""))
+        .map(poly => poly.filter(ring => ringVisible(ring, view)).map(ring => ringToPath(ring, project)).join(""))
         .join("")
 }
 
-type VenueLabel = {stadium: Stadium; x: number; y: number; w: number; h: number; cx: number; cy: number}
-
-// Collapses the group's fixtures to distinct venues we can place, projecting each
-// to viewBox coordinates. Fixtures whose venue we can't resolve are dropped (they
-// still appear in the table).
-function resolveVenues(matches: GroupMatch[], project: (lng: number, lat: number) => [number, number]): VenueLabel[] {
-    const byCity = new Map<string, VenueLabel>()
-    for (const m of matches) {
-        const stadium = resolveStadium(m.venue)
-        if (!stadium || byCity.has(stadium.city)) continue
-        const [x, y] = project(stadium.lng, stadium.lat)
-        const w = Math.max(stadium.name.length * (NAME_FONT * 0.56), stadium.city.length * (CITY_FONT * 0.6)) + 2 * LABEL_PAD_X
-        byCity.set(stadium.city, {stadium, x, y, w, h: LABEL_HEIGHT, cx: x, cy: y - LABEL_GAP - LABEL_HEIGHT / 2})
-    }
-    return [...byCity.values()]
+type VenueLabel = {
+    stadium: Stadium
+    matches: GroupMatch[]
+    x: number
+    y: number
+    w: number
+    h: number
+    cx: number
+    cy: number
 }
 
-// Nudges the labels apart so they don't overlap, while a light spring keeps each
-// one tugged back above its own dot. Pure 2D layout — no zoom, no per-frame work.
+// Collapses the group's fixtures to distinct venues we can place, projecting each
+// to viewBox coordinates and keeping every fixture hosted there (a venue can host
+// more than one match in a group). Fixtures whose venue we can't resolve are
+// dropped from the map (they still appear in the match list).
+function resolveVenues(matches: GroupMatch[], project: (lng: number, lat: number) => [number, number]): VenueLabel[] {
+    const byCity = new Map<string, {stadium: Stadium; matches: GroupMatch[]}>()
+    for (const m of matches) {
+        const stadium = resolveStadium(m.venue)
+        if (!stadium) continue
+        const entry = byCity.get(stadium.city)
+        if (entry) entry.matches.push(m)
+        else byCity.set(stadium.city, {stadium, matches: [m]})
+    }
+    return [...byCity.values()].map(({stadium, matches}) => {
+        const [x, y] = project(stadium.lng, stadium.lat)
+        const nameW = Math.max(stadium.name.length * (NAME_FONT * 0.56), stadium.city.length * (CITY_FONT * 0.6)) + 2 * LABEL_PAD_X
+        const w = Math.max(nameW, PILL_WIDTH)
+        const h = LABEL_HEIGHT + matches.length * (PILL_HEIGHT + PILL_GAP)
+        return {stadium, matches, x, y, w, h, cx: x, cy: y - LABEL_GAP - h / 2}
+    })
+}
+
+// Nudges the venue boxes (name label + its stack of match pills) apart so they
+// don't overlap, while a light spring keeps each one tugged back above its own
+// dot. Pure 2D layout — no zoom, no per-frame work.
 function declutter(labels: VenueLabel[], width: number, height: number): void {
     for (let iter = 0; iter < SEPARATION_ITERATIONS; iter++) {
         for (const a of labels) {
@@ -146,11 +197,15 @@ function declutter(labels: VenueLabel[], width: number, height: number): void {
 
 export default function GroupVenueMap({matches}: {matches: GroupMatch[]}): React.JSX.Element {
     const {paths, labels, height} = useMemo(() => {
-        const {project, height} = makeProjection()
+        const stadiums = matches
+            .map(m => resolveStadium(m.venue))
+            .filter((s): s is Stadium => s !== undefined)
+        const view = computeView(stadiums)
+        const {project, height} = makeProjection(view)
         const paths = HOST_CODES
             .map(code => getCountryGeometry(code))
             .filter((g): g is Polygon | MultiPolygon => g !== null)
-            .map(g => geometryToPath(g, project))
+            .map(g => geometryToPath(g, project, view))
         const labels = resolveVenues(matches, project)
         declutter(labels, VIEW_WIDTH, height)
         return {paths, labels, height}
@@ -162,7 +217,7 @@ export default function GroupVenueMap({matches}: {matches: GroupMatch[]}): React
             preserveAspectRatio="xMidYMid meet"
             className="h-full w-full"
             role="img"
-            aria-label="Map of venues across the host nations"
+            aria-label="Map of venues hosting this group's fixtures"
         >
             {paths.map((d, i) => (
                 <path
@@ -194,25 +249,58 @@ export default function GroupVenueMap({matches}: {matches: GroupMatch[]}): React
                 </g>
             ))}
 
-            {labels.map(l => (
-                <g key={`label-${l.stadium.city}`}>
-                    <rect
-                        x={l.cx - l.w / 2}
-                        y={l.cy - l.h / 2}
-                        width={l.w}
-                        height={l.h}
-                        rx={8}
-                        className="fill-white/90 stroke-slate-200 dark:fill-black/60 dark:stroke-white/10"
-                        strokeWidth={1}
-                    />
-                    <text x={l.cx} y={l.cy - 3} textAnchor="middle" className="fill-slate-800 dark:fill-gray-100" fontSize={NAME_FONT} fontWeight={600}>
-                        {l.stadium.name}
-                    </text>
-                    <text x={l.cx} y={l.cy + CITY_FONT} textAnchor="middle" className="fill-slate-400 dark:fill-gray-400" fontSize={CITY_FONT} letterSpacing={0.5}>
-                        {l.stadium.city.toUpperCase()}
-                    </text>
-                </g>
-            ))}
+            {labels.map(l => {
+                const nameCy = l.cy + l.h / 2 - LABEL_HEIGHT / 2
+                return (
+                    <g key={`label-${l.stadium.city}`}>
+                        <rect
+                            x={l.cx - l.w / 2}
+                            y={nameCy - LABEL_HEIGHT / 2}
+                            width={l.w}
+                            height={LABEL_HEIGHT}
+                            rx={8}
+                            className="fill-white/90 stroke-slate-200 dark:fill-black/60 dark:stroke-white/10"
+                            strokeWidth={1}
+                        />
+                        <text x={l.cx} y={nameCy - 3} textAnchor="middle" className="fill-slate-800 dark:fill-gray-100" fontSize={NAME_FONT} fontWeight={600}>
+                            {l.stadium.name}
+                        </text>
+                        <text x={l.cx} y={nameCy + CITY_FONT} textAnchor="middle" className="fill-slate-400 dark:fill-gray-400" fontSize={CITY_FONT} letterSpacing={0.5}>
+                            {l.stadium.city.toUpperCase()}
+                        </text>
+                    </g>
+                )
+            })}
+
+            {labels.flatMap(l => {
+                const nameTop = l.cy + l.h / 2 - LABEL_HEIGHT
+                return l.matches.map((m, i) => {
+                    const pillCy = nameTop - PILL_GAP - PILL_HEIGHT / 2 - i * (PILL_HEIGHT + PILL_GAP)
+                    return (
+                        <foreignObject
+                            key={`pill-${m.matchId}`}
+                            x={l.cx - PILL_WIDTH / 2}
+                            y={pillCy - PILL_HEIGHT / 2}
+                            width={PILL_WIDTH}
+                            height={PILL_HEIGHT}
+                        >
+                            <div xmlns="http://www.w3.org/1999/xhtml" style={{width: "100%", height: "100%"}}>
+                                <Link
+                                    href={`/app/match/${m.matchId}/predictions`}
+                                    className="flex h-full w-full items-center justify-center gap-1.5 rounded-full border border-slate-200 bg-white/95 px-2 shadow-sm transition-colors hover:bg-white dark:border-white/15 dark:bg-black/70 dark:hover:bg-black/90"
+                                    aria-label={`${m.homeTeam} vs ${m.awayTeam}`}
+                                >
+                                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                                    <img src={`https://flagcdn.com/w40/${m.homeFlagCode.toLowerCase()}.png`} alt={m.homeTeam} className="h-4 w-6 rounded-sm object-cover"/>
+                                    <span className="text-[10px] font-semibold text-slate-400 dark:text-gray-500">v</span>
+                                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                                    <img src={`https://flagcdn.com/w40/${m.awayFlagCode.toLowerCase()}.png`} alt={m.awayTeam} className="h-4 w-6 rounded-sm object-cover"/>
+                                </Link>
+                            </div>
+                        </foreignObject>
+                    )
+                })
+            })}
         </svg>
     )
 }

--- a/frontend/app/components/flags/group-venue-map.tsx
+++ b/frontend/app/components/flags/group-venue-map.tsx
@@ -284,7 +284,7 @@ export default function GroupVenueMap({matches}: {matches: GroupMatch[]}): React
                             width={PILL_WIDTH}
                             height={PILL_HEIGHT}
                         >
-                            <div xmlns="http://www.w3.org/1999/xhtml" style={{width: "100%", height: "100%"}}>
+                            <div style={{width: "100%", height: "100%"}}>
                                 <Link
                                     href={`/app/match/${m.matchId}/predictions`}
                                     className="flex h-full w-full items-center justify-center gap-1.5 rounded-full border border-slate-200 bg-white/95 px-2 shadow-sm transition-colors hover:bg-white dark:border-white/15 dark:bg-black/70 dark:hover:bg-black/90"

--- a/frontend/app/components/standings/group-match-list.tsx
+++ b/frontend/app/components/standings/group-match-list.tsx
@@ -1,0 +1,73 @@
+import React from "react"
+import Link from "next/link"
+import {MatchStateEnum} from "@/client"
+import {FlagImage} from "@/app/components/predictions/flag-image"
+import {LocalTime} from "@/app/components/predictions/local-time"
+import type {GroupMatch} from "@/app/components/flags/group-venue-map"
+
+interface GroupMatchListProps {
+    group: string
+    matches: GroupMatch[]
+}
+
+// Every fixture in the selected group, each linking through to its own match
+// page — the same destination the map's venue pills point to.
+export default function GroupMatchList({group, matches}: GroupMatchListProps): React.JSX.Element {
+    return (
+        <div className="rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-2xl shadow-cyan-500/10">
+            <div className="rounded-3xl bg-white dark:bg-gray-900/80 backdrop-blur-xl p-4 space-y-2">
+                <h3 className="px-1 text-xs font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400">
+                    Group {group} fixtures
+                </h3>
+                {matches.length === 0 ? (
+                    <p className="px-1 py-4 text-center text-sm text-slate-500 dark:text-gray-400">
+                        No fixtures scheduled yet.
+                    </p>
+                ) : (
+                    matches.map(m => <MatchRow key={m.matchId} match={m}/>)
+                )}
+            </div>
+        </div>
+    )
+}
+
+function MatchRow({match}: {match: GroupMatch}): React.JSX.Element {
+    const live = match.state === MatchStateEnum.Live
+    const completed = match.state === MatchStateEnum.Completed
+    const hasScore = match.homeScore !== undefined && match.awayScore !== undefined
+
+    return (
+        <Link
+            href={`/app/match/${match.matchId}/predictions`}
+            className="flex items-center gap-3 rounded-2xl border border-slate-900/5 bg-slate-900/[0.02] px-3 py-2.5 transition-colors hover:bg-slate-900/5 dark:border-white/5 dark:bg-white/[0.02] dark:hover:bg-white/5"
+        >
+            <div className="flex flex-1 items-center gap-2 min-w-0">
+                <FlagImage code={match.homeFlagCode.toLowerCase()} name={match.homeTeam} size={28}/>
+                <span className="truncate text-sm font-semibold text-slate-700 dark:text-gray-200">{match.homeTeam}</span>
+            </div>
+
+            <div className="flex shrink-0 flex-col items-center text-center">
+                {completed && hasScore ? (
+                    <span className="text-sm font-black tabular-nums text-slate-800 dark:text-gray-100">
+                        {match.homeScore} - {match.awayScore}
+                    </span>
+                ) : live && hasScore ? (
+                    <span className="inline-flex items-center gap-1 text-sm font-black tabular-nums text-rose-500">
+                        <span className="h-1.5 w-1.5 rounded-full bg-rose-500 animate-pulse"/>
+                        {match.homeScore} - {match.awayScore}
+                    </span>
+                ) : (
+                    <span className="text-xs font-semibold text-slate-400 dark:text-gray-500">vs</span>
+                )}
+                <span className="mt-0.5 text-[11px] text-slate-400 dark:text-gray-500">
+                    <LocalTime date={match.datetime}/>
+                </span>
+            </div>
+
+            <div className="flex flex-1 items-center justify-end gap-2 min-w-0">
+                <span className="truncate text-right text-sm font-semibold text-slate-700 dark:text-gray-200">{match.awayTeam}</span>
+                <FlagImage code={match.awayFlagCode.toLowerCase()} name={match.awayTeam} size={28}/>
+            </div>
+        </Link>
+    )
+}

--- a/frontend/app/components/standings/standings-groups.tsx
+++ b/frontend/app/components/standings/standings-groups.tsx
@@ -5,6 +5,7 @@ import {GroupStanding} from "@/client"
 import GroupTable from "@/app/components/standings/group-table"
 import GroupVenueMap from "@/app/components/flags/group-venue-map"
 import type {GroupMatch} from "@/app/components/flags/group-venue-map"
+import GroupMatchList from "@/app/components/standings/group-match-list"
 
 interface StandingsGroupsProps {
     groups: GroupStanding[]
@@ -74,6 +75,8 @@ export default function StandingsGroups({groups, matchesByGroup}: StandingsGroup
 
                 <GroupTable group={selected.group} standings={selected.standings}/>
             </div>
+
+            <GroupMatchList group={selected.group} matches={matches}/>
         </section>
     )
 }


### PR DESCRIPTION
The map now frames a dynamic bounding box around only the venues hosting the
selected group's fixtures instead of the full three-host-nation view. Each
venue gets a clickable flag-vs-flag pill per fixture it hosts, linking to the
match's predictions page. A new fixtures list under the map/table gives the
same match-page links in list form.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pt5eAGVnckAYCusPYQPBVx