### PR TITLE
Disable links for fixtures that haven't kicked off and preserve group on back nav

### DIFF
--- a/frontend/app/app/standings/page.tsx
+++ b/frontend/app/app/standings/page.tsx
@@ -53,7 +53,12 @@ function TableIcon({className}: {className?: string}): React.JSX.Element {
     )
 }
 
-export default async function StandingsPage(): Promise<React.JSX.Element> {
+export default async function StandingsPage(
+    {searchParams}: {searchParams: Promise<{[key: string]: string | string[] | undefined}>}
+): Promise<React.JSX.Element> {
+    const resolvedSearchParams = await searchParams
+    const groupParam = resolvedSearchParams["group"]
+    const initialGroup = typeof groupParam === "string" ? groupParam : undefined
     const config = await getConfigWithAuthHeader()
     const matchApi = new MatchApi(config)
     const [standings, liveMatches, upcomingMatches, completedMatches] = await Promise.all([
@@ -106,7 +111,7 @@ export default async function StandingsPage(): Promise<React.JSX.Element> {
                     </div>
                 ) : (
                     <>
-                        <StandingsGroups groups={standings.groups} matchesByGroup={matchesByGroup}/>
+                        <StandingsGroups groups={standings.groups} matchesByGroup={matchesByGroup} initialGroup={initialGroup}/>
 
                         <section className="space-y-4">
                             <div className="flex flex-col items-center text-center">

--- a/frontend/app/components/flags/group-venue-map.tsx
+++ b/frontend/app/components/flags/group-venue-map.tsx
@@ -3,7 +3,7 @@
 import React, {useMemo} from "react"
 import Link from "next/link"
 import type {MultiPolygon, Polygon, Position} from "geojson"
-import type {MatchStateEnum} from "@/client"
+import {MatchStateEnum} from "@/client"
 import {resolveStadium, Stadium} from "./stadium-coords"
 import {getCountryGeometry} from "./globe-utils"
 
@@ -276,6 +276,17 @@ export default function GroupVenueMap({matches}: {matches: GroupMatch[]}): React
                 const nameTop = l.cy + l.h / 2 - LABEL_HEIGHT
                 return l.matches.map((m, i) => {
                     const pillCy = nameTop - PILL_GAP - PILL_HEIGHT / 2 - i * (PILL_HEIGHT + PILL_GAP)
+                    const kickedOff = m.state === MatchStateEnum.Live || m.state === MatchStateEnum.Completed
+                    const pillClassName = "flex h-full w-full items-center justify-center gap-1.5 rounded-full border border-slate-200 bg-white/95 px-2 shadow-sm transition-colors hover:bg-white dark:border-white/15 dark:bg-black/70 dark:hover:bg-black/90"
+                    const pillContent = (
+                        <>
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img src={`https://flagcdn.com/w40/${m.homeFlagCode.toLowerCase()}.png`} alt={m.homeTeam} className="h-4 w-6 rounded-sm object-cover"/>
+                            <span className="text-[10px] font-semibold text-slate-400 dark:text-gray-500">v</span>
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img src={`https://flagcdn.com/w40/${m.awayFlagCode.toLowerCase()}.png`} alt={m.awayTeam} className="h-4 w-6 rounded-sm object-cover"/>
+                        </>
+                    )
                     return (
                         <foreignObject
                             key={`pill-${m.matchId}`}
@@ -285,17 +296,15 @@ export default function GroupVenueMap({matches}: {matches: GroupMatch[]}): React
                             height={PILL_HEIGHT}
                         >
                             <div style={{width: "100%", height: "100%"}}>
-                                <Link
-                                    href={`/app/match/${m.matchId}/predictions`}
-                                    className="flex h-full w-full items-center justify-center gap-1.5 rounded-full border border-slate-200 bg-white/95 px-2 shadow-sm transition-colors hover:bg-white dark:border-white/15 dark:bg-black/70 dark:hover:bg-black/90"
-                                    aria-label={`${m.homeTeam} vs ${m.awayTeam}`}
-                                >
-                                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                                    <img src={`https://flagcdn.com/w40/${m.homeFlagCode.toLowerCase()}.png`} alt={m.homeTeam} className="h-4 w-6 rounded-sm object-cover"/>
-                                    <span className="text-[10px] font-semibold text-slate-400 dark:text-gray-500">v</span>
-                                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                                    <img src={`https://flagcdn.com/w40/${m.awayFlagCode.toLowerCase()}.png`} alt={m.awayTeam} className="h-4 w-6 rounded-sm object-cover"/>
-                                </Link>
+                                {kickedOff ? (
+                                    <Link href={`/app/match/${m.matchId}/predictions`} className={pillClassName} aria-label={`${m.homeTeam} vs ${m.awayTeam}`}>
+                                        {pillContent}
+                                    </Link>
+                                ) : (
+                                    <div className={pillClassName} aria-label={`${m.homeTeam} vs ${m.awayTeam}`}>
+                                        {pillContent}
+                                    </div>
+                                )}
                             </div>
                         </foreignObject>
                     )

--- a/frontend/app/components/standings/group-match-list.tsx
+++ b/frontend/app/components/standings/group-match-list.tsx
@@ -34,13 +34,13 @@ export default function GroupMatchList({group, matches}: GroupMatchListProps): R
 function MatchRow({match}: {match: GroupMatch}): React.JSX.Element {
     const live = match.state === MatchStateEnum.Live
     const completed = match.state === MatchStateEnum.Completed
+    const kickedOff = live || completed
     const hasScore = match.homeScore !== undefined && match.awayScore !== undefined
 
-    return (
-        <Link
-            href={`/app/match/${match.matchId}/predictions`}
-            className="flex items-center gap-3 rounded-2xl border border-slate-900/5 bg-slate-900/[0.02] px-3 py-2.5 transition-colors hover:bg-slate-900/5 dark:border-white/5 dark:bg-white/[0.02] dark:hover:bg-white/5"
-        >
+    const className = "flex items-center gap-3 rounded-2xl border border-slate-900/5 bg-slate-900/[0.02] px-3 py-2.5 transition-colors hover:bg-slate-900/5 dark:border-white/5 dark:bg-white/[0.02] dark:hover:bg-white/5"
+
+    const content = (
+        <>
             <div className="flex flex-1 items-center gap-2 min-w-0">
                 <FlagImage code={match.homeFlagCode.toLowerCase()} name={match.homeTeam} size={28}/>
                 <span className="truncate text-sm font-semibold text-slate-700 dark:text-gray-200">{match.homeTeam}</span>
@@ -68,6 +68,18 @@ function MatchRow({match}: {match: GroupMatch}): React.JSX.Element {
                 <span className="truncate text-right text-sm font-semibold text-slate-700 dark:text-gray-200">{match.awayTeam}</span>
                 <FlagImage code={match.awayFlagCode.toLowerCase()} name={match.awayTeam} size={28}/>
             </div>
+        </>
+    )
+
+    // Fixtures that haven't kicked off yet don't have anything to show on the
+    // match page, so they're rendered as plain rows rather than links.
+    if (!kickedOff) {
+        return <div className={className}>{content}</div>
+    }
+
+    return (
+        <Link href={`/app/match/${match.matchId}/predictions`} className={className}>
+            {content}
         </Link>
     )
 }

--- a/frontend/app/components/standings/standings-groups.tsx
+++ b/frontend/app/components/standings/standings-groups.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, {useState} from "react"
+import {useRouter} from "next/navigation"
 import {GroupStanding} from "@/client"
 import GroupTable from "@/app/components/standings/group-table"
 import GroupVenueMap from "@/app/components/flags/group-venue-map"
@@ -10,18 +11,30 @@ import GroupMatchList from "@/app/components/standings/group-match-list"
 interface StandingsGroupsProps {
     groups: GroupStanding[]
     matchesByGroup: Record<string, GroupMatch[]>
+    initialGroup?: string
 }
 
 /**
  * Standings, one group at a time. A pill selector switches between groups; the
  * chosen group shows its table alongside a globe zoomed to the venues hosting
  * its fixtures, each marked with a pill of the matchup's flags.
+ *
+ * The selected group is mirrored into the URL (via replace, so it doesn't grow
+ * browser history) so that navigating to a match and back lands on the same
+ * group instead of resetting to the first one.
  */
-export default function StandingsGroups({groups, matchesByGroup}: StandingsGroupsProps): React.JSX.Element {
-    const [active, setActive] = useState(groups[0]?.group)
+export default function StandingsGroups({groups, matchesByGroup, initialGroup}: StandingsGroupsProps): React.JSX.Element {
+    const router = useRouter()
+    const initial = groups.find(g => g.group === initialGroup)?.group ?? groups[0]?.group
+    const [active, setActive] = useState(initial)
     const selected = groups.find(g => g.group === active) ?? groups[0]
     const matches = matchesByGroup[selected.group] ?? []
     const venueCount = new Set(matches.map(m => m.venue)).size
+
+    function selectGroup(group: string): void {
+        setActive(group)
+        router.replace(`/app/standings?group=${encodeURIComponent(group)}`, {scroll: false})
+    }
 
     return (
         <section className="space-y-5">
@@ -32,7 +45,7 @@ export default function StandingsGroups({groups, matchesByGroup}: StandingsGroup
                         <button
                             key={g.group}
                             type="button"
-                            onClick={() => setActive(g.group)}
+                            onClick={() => selectGroup(g.group)}
                             aria-pressed={isActive}
                             className={`flex h-9 min-w-9 items-center justify-center rounded-full px-3 text-sm font-bold transition-colors ${
                                 isActive


### PR DESCRIPTION
Standings showed clickable links for upcoming fixtures with nothing to
view yet, and the selected group reset to the first one whenever you
navigated to a match and back. Render upcoming fixtures as plain rows
(match list and venue map pills) and mirror the selected group into the
standings URL so it survives navigation.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0118Z5VhFDckWesp9uKLtg6t