### PR TITLE
Make flag loading resilient so a single CDN failure can't crash the g…

### DIFF
--- a/frontend/app/components/flags/flag-globe.tsx
+++ b/frontend/app/components/flags/flag-globe.tsx
@@ -2,21 +2,22 @@
 
 import React, {useEffect, useMemo, useRef, useState} from "react"
 import {Canvas, useFrame} from "@react-three/fiber"
-import {Line, OrbitControls, useTexture} from "@react-three/drei"
+import {Line, OrbitControls} from "@react-three/drei"
 import * as THREE from "three"
 import {useTheme} from "next-themes"
 import {COUNTRY_COORDS} from "./country-coords"
 import {WORLD_CUP_2026_STADIUMS} from "./stadium-coords"
 import {GLOBE_RADIUS, latLngToVec3, buildContinentGeometry, orientationForPosition, cropSquare} from "./globe-utils"
+import {useFlagTextures} from "./flag-textures"
 
 const FLAG_RADIUS = 1.92
 const FLAG_DISC_RADIUS = 0.09
 const FLAG_BORDER_WIDTH = 0.012
+const FLAG_PLACEHOLDER_COLOR = "#334155"
 const MIN_ANGLE = 0.11
 const RELAX_ITERATIONS = 220
 
 const COUNTRY_CODES = Object.keys(COUNTRY_COORDS)
-const FLAG_URLS = COUNTRY_CODES.map(c => `https://flagcdn.com/w80/${c}.png`)
 
 export type Match = {home: string; away: string}
 
@@ -228,9 +229,11 @@ function StarField() {
 }
 
 function Flags() {
-    const textures = useTexture(FLAG_URLS) as THREE.Texture[]
+    const textures = useFlagTextures(COUNTRY_CODES, "w80")
 
-    const markers = useMemo(() => {
+    // Positions only depend on the (stable) country set, so the expensive
+    // relaxation runs once rather than re-running as flags stream in.
+    const layout = useMemo(() => {
         const anchors = COUNTRY_CODES.map(code => {
             const [lat, lng] = COUNTRY_COORDS[code]
             return latLngToVec3(lat, lng, 1)
@@ -238,19 +241,27 @@ function Flags() {
         const relaxed = relaxOnSphere(anchors, MIN_ANGLE, RELAX_ITERATIONS)
 
         return COUNTRY_CODES.map((code, i) => {
-            const anchorPos = anchors[i].clone().multiplyScalar(GLOBE_RADIUS + 0.005)
             const flagPos = relaxed[i].clone().multiplyScalar(FLAG_RADIUS)
-            const frontTex = cropSquare(textures[i])
             return {
                 code,
-                anchorPos,
+                anchorPos: anchors[i].clone().multiplyScalar(GLOBE_RADIUS + 0.005),
                 flagPos,
                 rotation: orientationForPosition(flagPos),
-                frontTexture: frontTex,
-                backTexture: mirrorHorizontally(frontTex),
             }
         })
-    }, [textures])
+    }, [])
+
+    const markers = useMemo(() =>
+        layout.map((marker, i) => {
+            const texture = textures[i]
+            const frontTexture = texture ? cropSquare(texture) : null
+            return {
+                ...marker,
+                frontTexture,
+                backTexture: frontTexture ? mirrorHorizontally(frontTexture) : null,
+            }
+        }),
+    [layout, textures])
 
     return (
         <>
@@ -266,14 +277,23 @@ function Flags() {
                             <circleGeometry args={[FLAG_DISC_RADIUS + FLAG_BORDER_WIDTH, 48]}/>
                             <meshBasicMaterial color="#ffffff" side={THREE.DoubleSide}/>
                         </mesh>
-                        <mesh position={[0, 0, 0.001]}>
-                            <circleGeometry args={[FLAG_DISC_RADIUS, 48]}/>
-                            <meshBasicMaterial map={frontTexture} toneMapped={false} side={THREE.FrontSide}/>
-                        </mesh>
-                        <mesh position={[0, 0, -0.001]} rotation={[0, Math.PI, 0]}>
-                            <circleGeometry args={[FLAG_DISC_RADIUS, 48]}/>
-                            <meshBasicMaterial map={backTexture} toneMapped={false} side={THREE.FrontSide}/>
-                        </mesh>
+                        {frontTexture && backTexture ? (
+                            <>
+                                <mesh position={[0, 0, 0.001]}>
+                                    <circleGeometry args={[FLAG_DISC_RADIUS, 48]}/>
+                                    <meshBasicMaterial map={frontTexture} toneMapped={false} side={THREE.FrontSide}/>
+                                </mesh>
+                                <mesh position={[0, 0, -0.001]} rotation={[0, Math.PI, 0]}>
+                                    <circleGeometry args={[FLAG_DISC_RADIUS, 48]}/>
+                                    <meshBasicMaterial map={backTexture} toneMapped={false} side={THREE.FrontSide}/>
+                                </mesh>
+                            </>
+                        ) : (
+                            <mesh position={[0, 0, 0.001]}>
+                                <circleGeometry args={[FLAG_DISC_RADIUS, 48]}/>
+                                <meshBasicMaterial color={FLAG_PLACEHOLDER_COLOR} side={THREE.DoubleSide}/>
+                            </mesh>
+                        )}
                     </group>
                 </group>
             ))}

--- a/frontend/app/components/flags/flag-textures.ts
+++ b/frontend/app/components/flags/flag-textures.ts
@@ -1,0 +1,87 @@
+import {useEffect, useState} from "react"
+import * as THREE from "three"
+import {flagSrc, flagFallbackSrc} from "../../util/flag"
+
+// Resilient flag-texture loading for the WebGL globes.
+//
+// react-three-fiber's `useTexture` loads its URLs as one batch and rejects the
+// surrounding Suspense boundary if *any single* image fails — so one transient
+// flagcdn blip would tear down the whole canvas. That surfaced in Sentry as
+// "Could not load https://flagcdn.com/w80/<cc>.png: undefined" (the trailing
+// ": undefined" is r3f's `Could not load ${url}: ${err.message}` format, not a
+// malformed URL). These helpers load each flag independently, retry the primary
+// once, fall back to an independent proxy, and resolve `null` rather than throw
+// so a missing flag degrades to a placeholder disc instead of crashing.
+
+const loader = new THREE.TextureLoader()
+loader.setCrossOrigin("anonymous")
+
+const RETRY_DELAY_MS = 500
+const LOAD_TIMEOUT_MS = 8000
+const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+// Resolves the loaded texture, rejecting on load error or if the request hangs
+// past LOAD_TIMEOUT_MS so a stalled connection can't pin the globe on
+// placeholders forever (the image keeps loading; we just stop waiting on it).
+function loadOnce(url: string): Promise<THREE.Texture> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`timeout: ${url}`)), LOAD_TIMEOUT_MS)
+        loader.load(
+            url,
+            texture => {
+                clearTimeout(timer)
+                resolve(texture)
+            },
+            undefined,
+            () => {
+                clearTimeout(timer)
+                reject(new Error(url))
+            },
+        )
+    })
+}
+
+async function loadFlagTexture(code: string, resolution: string): Promise<THREE.Texture | null> {
+    // flagcdn, a quick retry on flagcdn (transient blip), then the proxy.
+    const attempts = [flagSrc(code, resolution), flagSrc(code, resolution), flagFallbackSrc(code, resolution)]
+    for (let i = 0; i < attempts.length; i++) {
+        if (i > 0) await delay(RETRY_DELAY_MS)
+        try {
+            return await loadOnce(attempts[i])
+        } catch {
+            // try the next source
+        }
+    }
+    return null
+}
+
+// Loads a flag per code, aligned to the input array; entries are null until
+// loaded and stay null if every source fails. `codes` is expected to be a
+// stable reference (e.g. a module-level constant).
+export function useFlagTextures(codes: string[], resolution: string): (THREE.Texture | null)[] {
+    const [textures, setTextures] = useState<(THREE.Texture | null)[]>(() => codes.map(() => null))
+    useEffect(() => {
+        let active = true
+        Promise.all(codes.map(code => loadFlagTexture(code, resolution))).then(result => {
+            if (active) setTextures(result)
+        })
+        return () => {
+            active = false
+        }
+    }, [codes, resolution])
+    return textures
+}
+
+export function useFlagTexture(code: string, resolution: string): THREE.Texture | null {
+    const [texture, setTexture] = useState<THREE.Texture | null>(null)
+    useEffect(() => {
+        let active = true
+        loadFlagTexture(code, resolution).then(result => {
+            if (active) setTexture(result)
+        })
+        return () => {
+            active = false
+        }
+    }, [code, resolution])
+    return texture
+}

--- a/frontend/app/components/flags/focused-globe.tsx
+++ b/frontend/app/components/flags/focused-globe.tsx
@@ -2,14 +2,16 @@
 
 import React, {useEffect, useMemo, useRef, useState} from "react"
 import {Canvas, useFrame, useThree} from "@react-three/fiber"
-import {Html, Line, OrbitControls, useTexture} from "@react-three/drei"
+import {Html, Line, OrbitControls} from "@react-three/drei"
 import * as THREE from "three"
 import {COUNTRY_COORDS} from "./country-coords"
 import {resolveStadium, Stadium} from "./stadium-coords"
 import {GLOBE_RADIUS, latLngToVec3, buildContinentGeometry, buildCountryFillGeometry, hasCountryFill, cropSquare} from "./globe-utils"
+import {useFlagTexture} from "./flag-textures"
 
 const FLAG_DISC_RADIUS = 0.09
 const FLAG_BORDER_WIDTH = 0.012
+const FLAG_PLACEHOLDER_COLOR = "#334155"
 const FLAG_ANCHOR_OFFSET = 0.005
 const FLAG_LIFT = 0.42
 const FLAG_CAMERA_TILT = 0.45
@@ -346,9 +348,9 @@ function mirrorHorizontally(source: THREE.Texture): THREE.Texture {
 }
 
 function FocusFlag({code, position, anchorRadius}: {code: string; position: THREE.Vector3; anchorRadius: number}) {
-    const texture = useTexture(`https://flagcdn.com/w320/${code}.png`) as THREE.Texture
-    const front = useMemo(() => cropSquare(texture), [texture])
-    const back = useMemo(() => mirrorHorizontally(front), [front])
+    const texture = useFlagTexture(code, "w320")
+    const front = useMemo(() => (texture ? cropSquare(texture) : null), [texture])
+    const back = useMemo(() => (front ? mirrorHorizontally(front) : null), [front])
     const {anchorPos, flagPos, surfaceNormal} = useMemo(() => {
         const dir = position.clone().normalize()
         return {
@@ -380,14 +382,23 @@ function FocusFlag({code, position, anchorRadius}: {code: string; position: THRE
                     <circleGeometry args={[FLAG_DISC_RADIUS + FLAG_BORDER_WIDTH, 48]}/>
                     <meshBasicMaterial color="#ffffff" side={THREE.DoubleSide}/>
                 </mesh>
-                <mesh position={[0, 0, 0.001]}>
-                    <circleGeometry args={[FLAG_DISC_RADIUS, 48]}/>
-                    <meshBasicMaterial map={front} toneMapped={false} side={THREE.FrontSide}/>
-                </mesh>
-                <mesh position={[0, 0, -0.001]} rotation={[0, Math.PI, 0]}>
-                    <circleGeometry args={[FLAG_DISC_RADIUS, 48]}/>
-                    <meshBasicMaterial map={back} toneMapped={false} side={THREE.FrontSide}/>
-                </mesh>
+                {front && back ? (
+                    <>
+                        <mesh position={[0, 0, 0.001]}>
+                            <circleGeometry args={[FLAG_DISC_RADIUS, 48]}/>
+                            <meshBasicMaterial map={front} toneMapped={false} side={THREE.FrontSide}/>
+                        </mesh>
+                        <mesh position={[0, 0, -0.001]} rotation={[0, Math.PI, 0]}>
+                            <circleGeometry args={[FLAG_DISC_RADIUS, 48]}/>
+                            <meshBasicMaterial map={back} toneMapped={false} side={THREE.FrontSide}/>
+                        </mesh>
+                    </>
+                ) : (
+                    <mesh position={[0, 0, 0.001]}>
+                        <circleGeometry args={[FLAG_DISC_RADIUS, 48]}/>
+                        <meshBasicMaterial color={FLAG_PLACEHOLDER_COLOR} side={THREE.DoubleSide}/>
+                    </mesh>
+                )}
             </group>
         </>
     )

--- a/frontend/app/components/flags/group-venue-map.tsx
+++ b/frontend/app/components/flags/group-venue-map.tsx
@@ -6,6 +6,17 @@ import type {MultiPolygon, Polygon, Position} from "geojson"
 import {MatchStateEnum} from "@/client"
 import {resolveStadium, Stadium} from "./stadium-coords"
 import {getCountryGeometry} from "./globe-utils"
+import {flagSrc, flagFallbackSrc} from "@/app/util/flag"
+
+// Swap to the fallback proxy once if flagcdn fails to serve the flag.
+function handleFlagError(code: string, resolution: string) {
+    return (event: React.SyntheticEvent<HTMLImageElement>) => {
+        const img = event.currentTarget
+        if (img.dataset.fallback) return
+        img.dataset.fallback = "1"
+        img.src = flagFallbackSrc(code, resolution)
+    }
+}
 
 // One fixture in a group, reduced to what the map and match list need to plot
 // and describe it, and link it to its match page.
@@ -281,10 +292,10 @@ export default function GroupVenueMap({matches}: {matches: GroupMatch[]}): React
                     const pillContent = (
                         <>
                             {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img src={`https://flagcdn.com/w40/${m.homeFlagCode.toLowerCase()}.png`} alt={m.homeTeam} className="h-4 w-6 rounded-sm object-cover"/>
+                            <img src={flagSrc(m.homeFlagCode, "w40")} alt={m.homeTeam} className="h-4 w-6 rounded-sm object-cover" onError={handleFlagError(m.homeFlagCode, "w40")}/>
                             <span className="text-[10px] font-semibold text-slate-400 dark:text-gray-500">v</span>
                             {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img src={`https://flagcdn.com/w40/${m.awayFlagCode.toLowerCase()}.png`} alt={m.awayTeam} className="h-4 w-6 rounded-sm object-cover"/>
+                            <img src={flagSrc(m.awayFlagCode, "w40")} alt={m.awayTeam} className="h-4 w-6 rounded-sm object-cover" onError={handleFlagError(m.awayFlagCode, "w40")}/>
                         </>
                     )
                     return (

--- a/frontend/app/components/predictions/flag-image.tsx
+++ b/frontend/app/components/predictions/flag-image.tsx
@@ -1,9 +1,20 @@
 import React from "react"
+import {flagSrc, flagFallbackSrc} from "@/app/util/flag"
 
 interface FlagImageProps {
     code: string
     name: string
     size?: number
+}
+
+// Swap to the fallback proxy once if flagcdn fails to serve the flag.
+function handleFlagError(code: string, resolution: string) {
+    return (event: React.SyntheticEvent<HTMLImageElement>) => {
+        const img = event.currentTarget
+        if (img.dataset.fallback) return
+        img.dataset.fallback = "1"
+        img.src = flagFallbackSrc(code, resolution)
+    }
 }
 
 export function FlagImage({code, name, size = 48}: FlagImageProps): React.JSX.Element {
@@ -15,7 +26,12 @@ export function FlagImage({code, name, size = 48}: FlagImageProps): React.JSX.El
             style={{width: size, height: size}}
         >
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={`https://flagcdn.com/${resolution}/${code}.png`} alt={name} className="h-full w-full object-cover"/>
+            <img
+                src={flagSrc(code, resolution)}
+                alt={name}
+                className="h-full w-full object-cover"
+                onError={handleFlagError(code, resolution)}
+            />
         </div>
     )
 }

--- a/frontend/app/util/flag.ts
+++ b/frontend/app/util/flag.ts
@@ -1,3 +1,19 @@
+const FLAGCDN_HOST = "flagcdn.com"
+
+// Primary flag image: flagcdn's sized PNGs (resolution is a width bucket like
+// "w40", "w80", "w320"). flagcdn sends `Access-Control-Allow-Origin: *`, which
+// the WebGL globes rely on to use the image as a texture.
+export function flagSrc(code: string, resolution: string): string {
+    return `https://${FLAGCDN_HOST}/${resolution}/${code.toLowerCase()}.png`
+}
+
+// Independent fallback path for when flagcdn drops a request: wsrv.nl is a
+// separate, CORS-enabled image proxy fetching the same flagcdn source, so a
+// transient flagcdn edge failure doesn't leave a broken flag.
+export function flagFallbackSrc(code: string, resolution: string): string {
+    return `https://wsrv.nl/?url=${FLAGCDN_HOST}/${resolution}/${code.toLowerCase()}.png`
+}
+
 export function getFlagUrl(flagCode: string): string {
-    return `https://flagcdn.com/${flagCode}.svg`
+    return `https://${FLAGCDN_HOST}/${flagCode}.svg`
 }


### PR DESCRIPTION
…lobe

The login page (and match-page) WebGL globes loaded every flag PNG as one batch via react-three-fiber's useTexture. r3f rejects the whole Suspense boundary if any single image fails, so one transient flagcdn hiccup tore down the canvas and surfaced in Sentry as
"Could not load https://flagcdn.com/w80/<cc>.png: undefined" (the trailing ": undefined" is r3f's "Could not load ${url}: ${err.message}" format over a DOM error Event with no .message — not a malformed URL).

Load each flag independently instead, with an escalating fallback chain: flagcdn -> quick retry on flagcdn -> wsrv.nl proxy (independent, CORS-enabled, same source) -> null. Each attempt is bounded by an 8s timeout. A flag that fails every source degrades to a neutral placeholder disc rather than crashing the canvas. The expensive sphere relaxation in flag-globe now runs once instead of re-running as textures stream in.

Apply the same fallback to the plain <img> flags (flag-image, group-venue-map) via shared flagSrc/flagFallbackSrc helpers and an onError that swaps to the proxy once.