### PR TITLE
Fix RSC crash: move flag <img> onError into a client component

### DIFF
--- a/frontend/app/components/flags/flag-img.tsx
+++ b/frontend/app/components/flags/flag-img.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import React from "react"
+import {flagSrc, flagFallbackSrc} from "@/app/util/flag"
+
+interface FlagImgProps {
+    code: string
+    resolution: string
+    alt: string
+    className?: string
+}
+
+// A flagcdn flag image that falls back to the wsrv.nl proxy once if flagcdn
+// drops the request. The onError handler is why this is a client component:
+// event handlers can't be passed to DOM elements from a server component, so
+// server components (e.g. FlagImage) render this leaf instead of a raw <img>.
+export function FlagImg({code, resolution, alt, className}: FlagImgProps): React.JSX.Element {
+    return (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+            src={flagSrc(code, resolution)}
+            alt={alt}
+            className={className}
+            onError={event => {
+                const img = event.currentTarget
+                if (img.dataset.fallback) return
+                img.dataset.fallback = "1"
+                img.src = flagFallbackSrc(code, resolution)
+            }}
+        />
+    )
+}

--- a/frontend/app/components/flags/group-venue-map.tsx
+++ b/frontend/app/components/flags/group-venue-map.tsx
@@ -6,17 +6,7 @@ import type {MultiPolygon, Polygon, Position} from "geojson"
 import {MatchStateEnum} from "@/client"
 import {resolveStadium, Stadium} from "./stadium-coords"
 import {getCountryGeometry} from "./globe-utils"
-import {flagSrc, flagFallbackSrc} from "@/app/util/flag"
-
-// Swap to the fallback proxy once if flagcdn fails to serve the flag.
-function handleFlagError(code: string, resolution: string) {
-    return (event: React.SyntheticEvent<HTMLImageElement>) => {
-        const img = event.currentTarget
-        if (img.dataset.fallback) return
-        img.dataset.fallback = "1"
-        img.src = flagFallbackSrc(code, resolution)
-    }
-}
+import {FlagImg} from "./flag-img"
 
 // One fixture in a group, reduced to what the map and match list need to plot
 // and describe it, and link it to its match page.
@@ -291,11 +281,9 @@ export default function GroupVenueMap({matches}: {matches: GroupMatch[]}): React
                     const pillClassName = "flex h-full w-full items-center justify-center gap-1.5 rounded-full border border-slate-200 bg-white/95 px-2 shadow-sm transition-colors hover:bg-white dark:border-white/15 dark:bg-black/70 dark:hover:bg-black/90"
                     const pillContent = (
                         <>
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img src={flagSrc(m.homeFlagCode, "w40")} alt={m.homeTeam} className="h-4 w-6 rounded-sm object-cover" onError={handleFlagError(m.homeFlagCode, "w40")}/>
+                            <FlagImg code={m.homeFlagCode} resolution="w40" alt={m.homeTeam} className="h-4 w-6 rounded-sm object-cover"/>
                             <span className="text-[10px] font-semibold text-slate-400 dark:text-gray-500">v</span>
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img src={flagSrc(m.awayFlagCode, "w40")} alt={m.awayTeam} className="h-4 w-6 rounded-sm object-cover" onError={handleFlagError(m.awayFlagCode, "w40")}/>
+                            <FlagImg code={m.awayFlagCode} resolution="w40" alt={m.awayTeam} className="h-4 w-6 rounded-sm object-cover"/>
                         </>
                     )
                     return (

--- a/frontend/app/components/predictions/flag-image.tsx
+++ b/frontend/app/components/predictions/flag-image.tsx
@@ -1,20 +1,10 @@
 import React from "react"
-import {flagSrc, flagFallbackSrc} from "@/app/util/flag"
+import {FlagImg} from "@/app/components/flags/flag-img"
 
 interface FlagImageProps {
     code: string
     name: string
     size?: number
-}
-
-// Swap to the fallback proxy once if flagcdn fails to serve the flag.
-function handleFlagError(code: string, resolution: string) {
-    return (event: React.SyntheticEvent<HTMLImageElement>) => {
-        const img = event.currentTarget
-        if (img.dataset.fallback) return
-        img.dataset.fallback = "1"
-        img.src = flagFallbackSrc(code, resolution)
-    }
 }
 
 export function FlagImage({code, name, size = 48}: FlagImageProps): React.JSX.Element {
@@ -25,13 +15,7 @@ export function FlagImage({code, name, size = 48}: FlagImageProps): React.JSX.El
             className={`rounded-full ${ringWidth} ring-slate-900/15 dark:ring-white/20 overflow-hidden shrink-0 bg-slate-900/5 dark:bg-white/10`}
             style={{width: size, height: size}}
         >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-                src={flagSrc(code, resolution)}
-                alt={name}
-                className="h-full w-full object-cover"
-                onError={handleFlagError(code, resolution)}
-            />
+            <FlagImg code={code} resolution={resolution} alt={name} className="h-full w-full object-cover"/>
         </div>
     )
 }


### PR DESCRIPTION
The previous change added an onError fallback to the plain <img> flags, but flag-image.tsx is a server component and event handlers can't be passed to DOM elements from server components, so navigating to a page rendering FlagImage threw "Event handlers cannot be passed to Client Component props".

Extract the flag <img> + proxy fallback into a shared client component (FlagImg) and use it from both FlagImage (server) and group-venue-map (client). This keeps FlagImage a server component, fixes the crash, and removes the duplicated onError handler.