### PR TITLE
Add standings link from main app screen and group filter on history page

### DIFF
--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -101,7 +101,18 @@ const Home = async ({searchParams}: {searchParams: Promise<Record<string, string
                     <HeadlineSuspense tournamentStarted={tournamentStarted} nextKickoff={tournamentState?.nextKickoff} hasLiveMatch={liveMatches.length > 0} supportedTeamId={profile?.supportedTeamId} streaks={streaks} />
 
                     <section id="matches" className="space-y-4">
-                        <SectionHeading title="Matches" count={liveMatches.length + upcomingMatches.length} action={<MatchesHelp/>}/>
+                        <SectionHeading
+                            title="Matches"
+                            count={liveMatches.length + upcomingMatches.length}
+                            action={
+                                <div className="flex items-center gap-3">
+                                    <Link href="/app/standings" className="text-xs font-semibold text-cyan-600 dark:text-cyan-300 hover:text-cyan-700 dark:hover:text-cyan-200 transition-colors">
+                                        Standings →
+                                    </Link>
+                                    <MatchesHelp/>
+                                </div>
+                            }
+                        />
                     <PredictionPanel liveMatches={liveMatches} upcomingMatches={upcomingMatches} completedMatches={recentCompleted} historyHref={historyHref} userChips={userChips} streaks={streaks} />
                 </section>
 

--- a/frontend/app/app/standings/page.tsx
+++ b/frontend/app/app/standings/page.tsx
@@ -8,17 +8,13 @@ import ThirdPlacedTable from "@/app/components/standings/third-placed-table"
 import StandingsRefresher from "@/app/components/standings/standings-refresher"
 import StandingsGroups from "@/app/components/standings/standings-groups"
 import type {GroupMatch} from "@/app/components/flags/group-venue-map"
+import {buildTeamGroupMap} from "@/app/util/group-matches"
 
 export const dynamic = "force-dynamic"
 
-// Matches don't carry a group letter, so we resolve it from the standings: both
-// teams in a group-stage fixture share a group, so a team-name lookup places the
-// fixture. Returns the group-stage fixtures bucketed by group.
+// Returns the group-stage fixtures bucketed by group.
 function bucketMatchesByGroup(groups: Standings["groups"], matches: Match[]): Record<string, GroupMatch[]> {
-    const teamGroup = new Map<string, string>()
-    for (const g of groups) {
-        for (const row of g.standings) teamGroup.set(row.teamName.toLowerCase(), g.group)
-    }
+    const teamGroup = buildTeamGroupMap(groups)
 
     const seen = new Set<string>()
     const byGroup: Record<string, GroupMatch[]> = {}

--- a/frontend/app/app/user/[userId]/history/page.tsx
+++ b/frontend/app/app/user/[userId]/history/page.tsx
@@ -1,6 +1,6 @@
 import {getConfigWithAuthHeader} from "@/app/api/client-config"
-import HistoryMatchCard from "@/app/components/history/history-match-card"
-import {LeaderboardInner, LeagueApi, ListMatchesFilterTypeEnum, Match, MatchApi} from "@/client"
+import HistoryGroupFilter from "@/app/components/history/history-group-filter"
+import {LeaderboardInner, LeagueApi, ListMatchesFilterTypeEnum, Match, MatchApi, Standings, StandingsApi} from "@/client"
 import BackButton from "@/app/components/back-button";
 import Link from "next/link";
 import React from "react";
@@ -10,6 +10,7 @@ import FormBadge from "@/app/components/leaderboard/form-badge";
 import {SECTION_EYEBROW} from "@/app/util/css-classes";
 import StreakBadges from "@/app/components/points/streak-badges";
 import {computeStreakStats} from "@/app/util/streaks";
+import {bucketMatchesByGroupLetter, KNOCKOUT_GROUP} from "@/app/util/group-matches";
 
 export default async function Home({
     params
@@ -50,9 +51,30 @@ export default async function Home({
         }
     }
 
-    const [leaderboardEntry, form, games] = await Promise.all([getEntry(), getUserForm(userId), getGames()])
+    async function getStandings(): Promise<Standings> {
+        try {
+            return await new StandingsApi(await getConfigWithAuthHeader()).getStandings()
+        } catch (error) {
+            console.log(error)
+            return {groups: [], thirdPlaced: []}
+        }
+    }
+
+    const [leaderboardEntry, form, games, standings] = await Promise.all([getEntry(), getUserForm(userId), getGames(), getStandings()])
 
     const streaks = computeStreakStats(games)
+    const matchesByGroup = bucketMatchesByGroupLetter(standings.groups, games)
+    const groupOrder = [
+        ...standings.groups.map(g => g.group).filter(group => matchesByGroup[group]?.length),
+        ...(matchesByGroup[KNOCKOUT_GROUP]?.length ? [KNOCKOUT_GROUP] : []),
+    ]
+    const mostRecentMatch = games.reduce<Match | undefined>(
+        (latest, m) => !latest || m.datetime.valueOf() > latest.datetime.valueOf() ? m : latest,
+        undefined
+    )
+    const initialGroup = mostRecentMatch
+        ? groupOrder.find(group => matchesByGroup[group]?.some(m => m.matchId === mostRecentMatch.matchId))
+        : undefined
     const user = leaderboardEntry?.user
     const fullName = user ? `${user.firstName} ${user.familyName}` : "Player"
     const initials = user ? `${user.firstName.charAt(0)}${user.familyName.charAt(0)}` : "?"
@@ -133,13 +155,11 @@ export default async function Home({
 
                 <section className="space-y-4">
                     <h2 className={SECTION_EYEBROW + " text-center"}>Match history</h2>
-                    <div className="flex flex-col items-center gap-3">
-                        {games.length > 0 ? games.map((match) => (
-                            <HistoryMatchCard match={match} key={match.matchId}/>
-                        )) : (
-                            <p className="py-8 text-center text-sm text-slate-500 dark:text-gray-400">No completed matches yet — check back once games have been played.</p>
-                        )}
-                    </div>
+                    {games.length > 0 ? (
+                        <HistoryGroupFilter matchesByGroup={matchesByGroup} groupOrder={groupOrder} initialGroup={initialGroup}/>
+                    ) : (
+                        <p className="py-8 text-center text-sm text-slate-500 dark:text-gray-400">No completed matches yet — check back once games have been played.</p>
+                    )}
                 </section>
             </div>
         </main>

--- a/frontend/app/components/history/history-group-filter.tsx
+++ b/frontend/app/components/history/history-group-filter.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import React, {useState} from "react"
+import {Match} from "@/client"
+import HistoryMatchCard from "@/app/components/history/history-match-card"
+import {KNOCKOUT_GROUP} from "@/app/util/group-matches"
+
+interface HistoryGroupFilterProps {
+    matchesByGroup: Record<string, Match[]>
+    groupOrder: string[]
+    initialGroup?: string
+}
+
+export default function HistoryGroupFilter({matchesByGroup, groupOrder, initialGroup}: HistoryGroupFilterProps): React.JSX.Element {
+    const [active, setActive] = useState(initialGroup ?? groupOrder[0])
+    const matches = matchesByGroup[active] ?? []
+
+    return (
+        <div className="space-y-4">
+            {groupOrder.length > 1 && (
+                <div className="flex flex-wrap justify-center gap-2">
+                    {groupOrder.map(group => {
+                        const isActive = group === active
+                        return (
+                            <button
+                                key={group}
+                                type="button"
+                                onClick={() => setActive(group)}
+                                aria-pressed={isActive}
+                                className={`flex h-9 items-center justify-center rounded-full px-3 text-sm font-bold transition-colors ${
+                                    isActive
+                                        ? "bg-gradient-to-br from-blue-500 via-cyan-400 to-teal-300 text-white shadow-lg shadow-cyan-500/30"
+                                        : "bg-slate-900/5 text-slate-600 hover:bg-slate-900/10 dark:bg-white/5 dark:text-gray-300 dark:hover:bg-white/10"
+                                }`}
+                            >
+                                {group === KNOCKOUT_GROUP ? group : `Group ${group}`}
+                            </button>
+                        )
+                    })}
+                </div>
+            )}
+
+            <div className="flex flex-col items-center gap-3">
+                {matches.length > 0 ? matches.map(match => (
+                    <HistoryMatchCard match={match} key={match.matchId}/>
+                )) : (
+                    <p className="py-8 text-center text-sm text-slate-500 dark:text-gray-400">No matches in this group yet.</p>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/frontend/app/util/group-matches.ts
+++ b/frontend/app/util/group-matches.ts
@@ -1,0 +1,28 @@
+import {Match, MatchRoundEnum, Standings} from "@/client"
+
+export const KNOCKOUT_GROUP = "Knockout"
+
+// Matches don't carry a group letter, so we resolve it from the standings: both
+// teams in a group-stage fixture share a group, so a team-name lookup places it.
+export function buildTeamGroupMap(groups: Standings["groups"]): Map<string, string> {
+    const teamGroup = new Map<string, string>()
+    for (const g of groups) {
+        for (const row of g.standings) teamGroup.set(row.teamName.toLowerCase(), g.group)
+    }
+    return teamGroup
+}
+
+export function resolveMatchGroup(match: Match, teamGroup: Map<string, string>): string {
+    if (match.round !== MatchRoundEnum.GroupStage) return KNOCKOUT_GROUP
+    return teamGroup.get(match.homeTeam.toLowerCase()) ?? teamGroup.get(match.awayTeam.toLowerCase()) ?? KNOCKOUT_GROUP
+}
+
+export function bucketMatchesByGroupLetter(groups: Standings["groups"], matches: Match[]): Record<string, Match[]> {
+    const teamGroup = buildTeamGroupMap(groups)
+    const byGroup: Record<string, Match[]> = {}
+    for (const m of matches) {
+        const key = resolveMatchGroup(m, teamGroup)
+        ;(byGroup[key] ??= []).push(m)
+    }
+    return byGroup
+}


### PR DESCRIPTION
Surfaces the standings page from the Matches section header, and replaces
the flat match-history scroll with a group-stage pill selector (defaulting
to the most recent match's group) plus a Knockout bucket for non-group
fixtures. Extracted the team-to-group resolution shared with the standings
page into app/util/group-matches.ts.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016VZzMkUWkskjmH9vzdEQ8W