### PR TITLE
Add stage tabs to league leaderboards and global Group Stage/Knockout leagues

### DIFF
--- a/contract/api-contract.yaml
+++ b/contract/api-contract.yaml
@@ -1469,6 +1469,15 @@ paths:
           name: page
           schema:
             type: string
+        - in: query
+          name: stage
+          description: Restrict the leaderboard to points earned in a given stage of the tournament. Defaults to ALL.
+          schema:
+            type: string
+            enum:
+              - ALL
+              - GROUP_STAGE
+              - KNOCKOUT
       responses:
         '200':
           description: Successful response

--- a/frontend/app/app/league/[leagueId]/leaderboard/page.tsx
+++ b/frontend/app/app/league/[leagueId]/leaderboard/page.tsx
@@ -1,18 +1,27 @@
 import React, { Suspense } from "react";
 import Link from "next/link";
 import Leaderboard from "@/app/components/leaderboard/leaderboard";
+import StageTabs from "@/app/components/leaderboard/stage-tabs";
 import Share from "./share";
 import Leave from "./leave";
 import JustCreatedModal from "./just-created-modal";
 import InvitePrompt from "./invite-prompt";
 import BackButton from "@/app/components/back-button";
 import {getConfigWithAuthHeader} from "@/app/api/client-config";
-import {LeagueApi, LeagueKindEnum} from "@/client";
+import {GetLeagueLeaderboardStageEnum, LeagueApi, LeagueKindEnum} from "@/client";
 import {PitchPerspective} from "@/app/components/atmosphere";
 
+function parseStage(stageParam: string | string[] | undefined): GetLeagueLeaderboardStageEnum {
+    const value = typeof stageParam === "string" ? stageParam : undefined
+    return Object.values(GetLeagueLeaderboardStageEnum).find(stage => stage === value)
+        ?? GetLeagueLeaderboardStageEnum.All
+}
 
-export default async function Home({ params }: { params: Promise<{ leagueId: string }> }): Promise<React.JSX.Element> {
+export default async function Home(
+    { params, searchParams }: { params: Promise<{ leagueId: string }>, searchParams: Promise<{ [key: string]: string | string[] | undefined }> }
+): Promise<React.JSX.Element> {
     const { leagueId } = await params
+    const stage = parseStage((await searchParams)["stage"])
 
     const league = await new LeagueApi(await getConfigWithAuthHeader())
         .getLeague({ leagueId })
@@ -40,8 +49,9 @@ export default async function Home({ params }: { params: Promise<{ leagueId: str
                     </div>
                 </header>
 
-                <section className="flex flex-col items-center">
-                    <Leaderboard shouldPaginate={true} leagueId={leagueId} limit={false} />
+                <section className="flex flex-col items-center space-y-5">
+                    <StageTabs leagueId={leagueId} activeStage={stage} />
+                    <Leaderboard shouldPaginate={true} leagueId={leagueId} limit={false} stage={stage} />
                     {showInvitePrompt && league && (
                         <InvitePrompt leagueId={leagueId} leagueName={league.name}/>
                     )}

--- a/frontend/app/components/leaderboard/entries.tsx
+++ b/frontend/app/components/leaderboard/entries.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {GetLeagueLeaderboard200Response, LeagueApi} from "@/client";
+import {GetLeagueLeaderboard200Response, GetLeagueLeaderboardStageEnum, LeagueApi} from "@/client";
 import {getConfigWithAuthHeader} from "@/app/api/client-config";
 import {filterWithContext} from "@/app/util/array";
 import {getUserId} from "@/app/auth/jwt-handler";
@@ -9,7 +9,8 @@ import {getUserForm} from "@/app/components/leaderboard/get-user-form";
 export interface EntriesProps {
     leagueId: string,
     limit: boolean,
-    shouldPaginate: boolean
+    shouldPaginate: boolean,
+    stage?: GetLeagueLeaderboardStageEnum
 }
 
 function TrophyIcon({className}: {className?: string}): React.JSX.Element {
@@ -31,7 +32,7 @@ export default async function Entries(props: EntriesProps): Promise<React.JSX.El
     async function getLeaderboard(): Promise<GetLeagueLeaderboard200Response | undefined> {
         try {
             const leagueApi = new LeagueApi(await getConfigWithAuthHeader())
-            return await leagueApi.getLeagueLeaderboard({leagueId: props.leagueId, pageSize: "200"})
+            return await leagueApi.getLeagueLeaderboard({leagueId: props.leagueId, pageSize: "200", stage: props.stage})
         } catch (error) {
             return undefined
         }

--- a/frontend/app/components/leaderboard/leaderboard.tsx
+++ b/frontend/app/components/leaderboard/leaderboard.tsx
@@ -1,18 +1,20 @@
 import React, { Suspense } from "react";
 import Entries from "@/app/components/leaderboard/entries";
 import LeaderboardSkeleton from "@/app/components/leaderboard/leaderboard-skeleton";
+import {GetLeagueLeaderboardStageEnum} from "@/client";
 
 interface LeaderboardProps {
     leagueId: string,
     limit: boolean,
-    shouldPaginate: boolean
+    shouldPaginate: boolean,
+    stage?: GetLeagueLeaderboardStageEnum
 }
 
 export default function Leaderboard(props: LeaderboardProps): React.JSX.Element {
     return (
         <div className="w-full mx-auto flex flex-col items-center">
             <Suspense fallback={<LeaderboardSkeleton />}>
-                <Entries shouldPaginate={props.shouldPaginate} leagueId={props.leagueId} limit={props.limit} />
+                <Entries shouldPaginate={props.shouldPaginate} leagueId={props.leagueId} limit={props.limit} stage={props.stage} />
             </Suspense>
         </div>
     )

--- a/frontend/app/components/leaderboard/stage-tabs.tsx
+++ b/frontend/app/components/leaderboard/stage-tabs.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import React from "react"
+import {useRouter} from "next/navigation"
+import {GetLeagueLeaderboardStageEnum} from "@/client"
+
+interface StageTabsProps {
+    leagueId: string
+    activeStage: GetLeagueLeaderboardStageEnum
+}
+
+const STAGES: { value: GetLeagueLeaderboardStageEnum, label: string }[] = [
+    {value: GetLeagueLeaderboardStageEnum.All, label: "All"},
+    {value: GetLeagueLeaderboardStageEnum.GroupStage, label: "Group Stage"},
+    {value: GetLeagueLeaderboardStageEnum.Knockout, label: "Knockout"},
+]
+
+// Mirrors the selected stage into the URL (via replace, so it doesn't grow
+// browser history) so the leaderboard re-fetches filtered to that stage.
+export default function StageTabs({leagueId, activeStage}: StageTabsProps): React.JSX.Element {
+    const router = useRouter()
+
+    function selectStage(stage: GetLeagueLeaderboardStageEnum): void {
+        const query = stage === GetLeagueLeaderboardStageEnum.All ? "" : `?stage=${stage}`
+        router.replace(`/app/league/${leagueId}/leaderboard${query}`, {scroll: false})
+    }
+
+    return (
+        <div className="flex flex-wrap justify-center gap-2">
+            {STAGES.map(({value, label}) => {
+                const isActive = value === activeStage
+                return (
+                    <button
+                        key={value}
+                        type="button"
+                        onClick={() => selectStage(value)}
+                        aria-pressed={isActive}
+                        className={`flex h-9 items-center justify-center rounded-full px-4 text-sm font-bold transition-colors ${
+                            isActive
+                                ? "bg-gradient-to-br from-blue-500 via-cyan-400 to-teal-300 text-white shadow-lg shadow-cyan-500/30"
+                                : "bg-slate-900/5 text-slate-600 hover:bg-slate-900/10 dark:bg-white/5 dark:text-gray-300 dark:hover:bg-white/10"
+                        }`}
+                    >
+                        {label}
+                    </button>
+                )
+            })}
+        </div>
+    )
+}

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/League.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/League.kt
@@ -32,8 +32,10 @@ import scorcerer.server.extractUserId
 import scorcerer.server.fromJson
 import scorcerer.server.toJson
 import scorcerer.utils.LeaderboardService
+import scorcerer.utils.LeaderboardStage
 import scorcerer.utils.calculateGlobalLeaderboard
 import scorcerer.utils.calculateMovement
+import scorcerer.utils.calculateStageLeaderboard
 import scorcerer.utils.filterLeaderboardToLeague
 import scorcerer.utils.toUser
 import kotlin.math.min
@@ -93,28 +95,36 @@ fun leagueRoutes(contexts: RequestContexts, leaderboardService: LeaderboardServi
         val leagueId = req.path("leagueId")!!
         val pageSize = req.query("pageSize")
         val page = req.query("page")
+        val stage = req.query("stage")?.let { stageParam ->
+            LeaderboardStage.entries.find { it.name == stageParam }
+                ?: throw ApiResponseError(Response(Status.BAD_REQUEST).body("Invalid stage"))
+        } ?: LeaderboardStage.ALL
         val leagueName = transaction {
             LeagueTable.select(LeagueTable.name).where { LeagueTable.id eq leagueId }.singleOrNull()?.get(LeagueTable.name)
         } ?: throw ApiResponseError(Response(Status.BAD_REQUEST).body("League does not exist"))
-        val (latestMatchDay, latestGlobalLeaderboard) = runBlocking {
-            val matchDay = leaderboardService.getLatestLeaderboardMatchDay()
-            val leaderboard = leaderboardService.getLeaderboard(matchDay)
-            matchDay to (
-                leaderboard ?: run {
-                    val computed = calculateGlobalLeaderboard(null)
-                    leaderboardService.writeLeaderboard(computed, 0)
-                    computed
-                }
-                )
-        }
-        val response = if (leagueId == "global") {
-            paginateLeaderboard(leagueName, sortLeaderboard(latestGlobalLeaderboard), page, pageSize)
+        val response = if (stage != LeaderboardStage.ALL) {
+            paginateLeaderboard(leagueName, calculateStageLeaderboard(leagueId, stage), page, pageSize)
         } else {
-            val leagueUserIds = getLeagueUserIds(leagueId)
-            val previousGlobalLeaderboard = runBlocking { leaderboardService.getPreviousLeaderboard(latestMatchDay) }
-            val filteredLeague = filterLeaderboardToLeague(latestGlobalLeaderboard, leagueUserIds)
-            val previousFilteredLeague = filterLeaderboardToLeague(previousGlobalLeaderboard, leagueUserIds)
-            paginateLeaderboard(leagueName, sortLeaderboard(calculateMovement(filteredLeague, previousFilteredLeague)), page, pageSize)
+            val (latestMatchDay, latestGlobalLeaderboard) = runBlocking {
+                val matchDay = leaderboardService.getLatestLeaderboardMatchDay()
+                val leaderboard = leaderboardService.getLeaderboard(matchDay)
+                matchDay to (
+                    leaderboard ?: run {
+                        val computed = calculateGlobalLeaderboard(null)
+                        leaderboardService.writeLeaderboard(computed, 0)
+                        computed
+                    }
+                    )
+            }
+            if (leagueId == "global") {
+                paginateLeaderboard(leagueName, sortLeaderboard(latestGlobalLeaderboard), page, pageSize)
+            } else {
+                val leagueUserIds = getLeagueUserIds(leagueId)
+                val previousGlobalLeaderboard = runBlocking { leaderboardService.getPreviousLeaderboard(latestMatchDay) }
+                val filteredLeague = filterLeaderboardToLeague(latestGlobalLeaderboard, leagueUserIds)
+                val previousFilteredLeague = filterLeaderboardToLeague(previousGlobalLeaderboard, leagueUserIds)
+                paginateLeaderboard(leagueName, sortLeaderboard(calculateMovement(filteredLeague, previousFilteredLeague)), page, pageSize)
+            }
         }
         Response(Status.OK).body(response.toJson())
     },

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/User.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/User.kt
@@ -51,25 +51,33 @@ data class OAuthSignupRequest(val userId: String, val email: String, val firstNa
 
 data class OAuthSignupResponse(val idToken: String, val refreshToken: String, val userId: String, val isAdmin: Boolean)
 
-private fun addToGlobalLeague(userId: String) {
+// Auto-create (if needed) and join a tournament-wide league that every member belongs to,
+// e.g. "global", "group-stage", "knockout".
+private fun addToStandingLeague(userId: String, leagueId: String, leagueName: String) {
     try {
         transaction {
-            val globalLeagueExists = LeagueTable.selectAll().where { LeagueTable.id eq "global" }.count() > 0
-            if (!globalLeagueExists) {
+            val leagueExists = LeagueTable.selectAll().where { LeagueTable.id eq leagueId }.count() > 0
+            if (!leagueExists) {
                 LeagueTable.insert {
-                    it[name] = "Global"
-                    it[id] = "global"
+                    it[name] = leagueName
+                    it[id] = leagueId
                     it[kind] = LeagueKind.GLOBAL
                 }
             }
             LeagueMembershipTable.insert {
                 it[memberId] = userId
-                it[leagueId] = "global"
+                it[this.leagueId] = leagueId
             }
         }
     } catch (_: Exception) {
-        // Already in global league
+        // Already a member
     }
+}
+
+private fun addToGlobalLeague(userId: String) {
+    addToStandingLeague(userId, "global", "Global")
+    addToStandingLeague(userId, "group-stage", "Group Stage")
+    addToStandingLeague(userId, "knockout", "Knockout")
 }
 
 // Auto-create (if needed) and join the league for the team a user supports.

--- a/lambdas/src/main/kotlin/scorcerer/utils/Leaderboard.kt
+++ b/lambdas/src/main/kotlin/scorcerer/utils/Leaderboard.kt
@@ -12,12 +12,65 @@ import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.openapitools.server.models.CountryLeaderboardInner
 import org.openapitools.server.models.LeaderboardInner
+import org.openapitools.server.models.User
 import scorcerer.server.db.tables.LeagueMembershipTable
+import scorcerer.server.db.tables.MatchRound
 import scorcerer.server.db.tables.MemberTable
 import scorcerer.server.db.tables.TeamTable
 import scorcerer.server.fromJson
 import scorcerer.server.log
 import scorcerer.server.toJson
+
+enum class LeaderboardStage { ALL, GROUP_STAGE, KNOCKOUT }
+
+private val knockoutRounds = MatchRound.entries.filterNot { it == MatchRound.GROUP_STAGE }
+
+// Unlike calculateGlobalLeaderboard, this isn't cached per match day: it's a cheap
+// on-the-fly aggregation, and stage-filtered views don't need movement tracking.
+fun calculateStageLeaderboard(leagueId: String, stage: LeaderboardStage): List<LeaderboardInner> {
+    require(stage != LeaderboardStage.ALL) { "ALL stage does not use calculateStageLeaderboard" }
+    val rounds = if (stage == LeaderboardStage.GROUP_STAGE) listOf(MatchRound.GROUP_STAGE) else knockoutRounds
+
+    val users = transaction {
+        val pointsByUser = pointsByUserForRounds(rounds)
+        (LeagueMembershipTable innerJoin MemberTable)
+            .join(TeamTable, JoinType.LEFT, MemberTable.supportedTeamId, TeamTable.id)
+            .select(
+                MemberTable.id,
+                MemberTable.firstName,
+                MemberTable.familyName,
+                MemberTable.doublePointsChips,
+                MemberTable.oneOutChips,
+                MemberTable.crowdChips,
+                TeamTable.name,
+                TeamTable.flagCode,
+            )
+            .where { LeagueMembershipTable.leagueId eq leagueId }
+            .map { row ->
+                User(
+                    row[MemberTable.firstName],
+                    row[MemberTable.familyName],
+                    row[MemberTable.id],
+                    row[MemberTable.doublePointsChips],
+                    row[MemberTable.oneOutChips],
+                    row[MemberTable.crowdChips],
+                    0,
+                    pointsByUser[row[MemberTable.id]] ?: 0,
+                    row.getOrNull(TeamTable.name)?.toTitleCase(),
+                    row.getOrNull(TeamTable.flagCode),
+                )
+            }
+    }
+
+    val sortedUsers = users.sortedByDescending { it.livePoints }
+    var currentPosition = 0
+    var previousPoints = Int.MAX_VALUE
+    return sortedUsers.mapIndexed { index, user ->
+        if (user.livePoints < previousPoints) currentPosition = index + 1
+        previousPoints = user.livePoints
+        LeaderboardInner(currentPosition, user, LeaderboardInner.Movement.UNCHANGED)
+    }
+}
 
 fun filterLeaderboardToLeague(
     globalLeaderboard: List<LeaderboardInner>?,

--- a/lambdas/src/main/kotlin/scorcerer/utils/LivePoints.kt
+++ b/lambdas/src/main/kotlin/scorcerer/utils/LivePoints.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.v1.core.sum
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.openapitools.server.models.Match
+import scorcerer.server.db.tables.MatchRound
 import scorcerer.server.db.tables.MatchTable
 import scorcerer.server.db.tables.PredictionTable
 
@@ -27,4 +28,16 @@ fun livePointsForUser(userId: String): Int {
         .select(PredictionTable.points.sum())
         .where { (PredictionTable.matchId inList liveMatchIds) and (PredictionTable.memberId eq userId) }
         .firstOrNull()?.get(PredictionTable.points.sum()) ?: 0
+}
+
+// Points earned across matches in the given rounds, live or completed (prediction.points
+// is written as soon as a match is scored, regardless of its state).
+fun pointsByUserForRounds(rounds: List<MatchRound>): Map<String, Int> {
+    val matchIds = MatchTable.selectAll().where { MatchTable.round inList rounds }.map { it[MatchTable.id] }
+    if (matchIds.isEmpty()) return emptyMap()
+    return PredictionTable
+        .select(PredictionTable.memberId, PredictionTable.points.sum())
+        .where { PredictionTable.matchId inList matchIds }
+        .groupBy(PredictionTable.memberId)
+        .associate { it[PredictionTable.memberId] to (it[PredictionTable.points.sum()] ?: 0) }
 }

--- a/lambdas/src/main/resources/db/migration/V13__stage_leagues.sql
+++ b/lambdas/src/main/resources/db/migration/V13__stage_leagues.sql
@@ -1,0 +1,12 @@
+-- Two new global leagues, "Group Stage" and "Knockout", which (like "Global")
+-- every member belongs to. Their leaderboards are filtered to points earned
+-- on matches in that stage (see calculateStageLeaderboard).
+
+INSERT INTO league (id, name, kind) VALUES ('group-stage', 'Group Stage', 'GLOBAL');
+INSERT INTO league (id, name, kind) VALUES ('knockout', 'Knockout', 'GLOBAL');
+
+INSERT INTO league_membership (member_id, league_id)
+SELECT id, 'group-stage' FROM member;
+
+INSERT INTO league_membership (member_id, league_id)
+SELECT id, 'knockout' FROM member;

--- a/lambdas/src/test/kotlin/scorcerer/Utils.kt
+++ b/lambdas/src/test/kotlin/scorcerer/Utils.kt
@@ -38,6 +38,7 @@ fun givenMatchExists(
     matchDay: Int = 1,
     homeScore: Int? = null,
     awayScore: Int? = null,
+    round: MatchRound = MatchRound.GROUP_STAGE,
 ): String {
     return (
         transaction {
@@ -48,7 +49,7 @@ fun givenMatchExists(
                 it[this.state] = matchState
                 it[this.venue] = "Test Venue"
                 it[this.matchDay] = matchDay
-                it[this.round] = MatchRound.GROUP_STAGE
+                it[this.round] = round
                 if (homeScore != null) it[this.homeScore] = homeScore
                 if (awayScore != null) it[this.awayScore] = awayScore
             }

--- a/lambdas/src/test/kotlin/scorcerer/resources/LeagueTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/resources/LeagueTest.kt
@@ -14,12 +14,18 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.openapitools.server.models.CreateLeague200Response
+import org.openapitools.server.models.GetLeagueLeaderboard200Response
 import org.openapitools.server.models.League
+import org.openapitools.server.models.Match
 import scorcerer.DatabaseTest
 import scorcerer.givenLeagueExists
+import scorcerer.givenMatchExists
+import scorcerer.givenPredictionExists
+import scorcerer.givenTeamExists
 import scorcerer.givenUserExists
 import scorcerer.givenUserInLeague
 import scorcerer.server.db.tables.LeagueMembershipTable
+import scorcerer.server.db.tables.MatchRound
 import scorcerer.server.fromJson
 import scorcerer.server.resources.leagueRoutes
 import scorcerer.utils.LeaderboardS3Service
@@ -102,6 +108,54 @@ class LeagueTest : DatabaseTest() {
         givenLeagueExists("test-league", "Test League")
         val response = handler(Request(Method.POST, "/league/test-league/join"))
         response.status shouldBe Status.OK
+    }
+
+    @Test
+    fun leaderboardFilteredToGroupStageOnlyCountsGroupStagePoints() {
+        givenLeagueExists("test-league", "Test League")
+        givenUserInLeague("test-user", "test-league")
+        givenUserExists("another-user", "Another")
+        givenUserInLeague("another-user", "test-league")
+        val home = givenTeamExists("Home")
+        val away = givenTeamExists("Away")
+        val groupStageMatch = givenMatchExists(home, away, matchState = Match.State.COMPLETED, round = MatchRound.GROUP_STAGE)
+        val knockoutMatch = givenMatchExists(home, away, matchState = Match.State.COMPLETED, round = MatchRound.FINAL)
+        givenPredictionExists(groupStageMatch, "test-user", 1, 0, points = 3)
+        givenPredictionExists(knockoutMatch, "test-user", 1, 0, points = 5)
+        givenPredictionExists(groupStageMatch, "another-user", 1, 0, points = 1)
+
+        val response = handler(Request(Method.GET, "/league/test-league/leaderboard?stage=GROUP_STAGE"))
+        response.status shouldBe Status.OK
+        val body: GetLeagueLeaderboard200Response = response.bodyString().fromJson()
+        val testUserEntry = body.leaderboard.find { it.user.userId == "test-user" }!!
+        val anotherUserEntry = body.leaderboard.find { it.user.userId == "another-user" }!!
+        testUserEntry.user.livePoints shouldBe 3
+        anotherUserEntry.user.livePoints shouldBe 1
+        testUserEntry.position shouldBe 1
+    }
+
+    @Test
+    fun leaderboardFilteredToKnockoutOnlyCountsKnockoutPoints() {
+        givenLeagueExists("test-league", "Test League")
+        givenUserInLeague("test-user", "test-league")
+        val home = givenTeamExists("Home")
+        val away = givenTeamExists("Away")
+        val groupStageMatch = givenMatchExists(home, away, matchState = Match.State.COMPLETED, round = MatchRound.GROUP_STAGE)
+        val knockoutMatch = givenMatchExists(home, away, matchState = Match.State.COMPLETED, round = MatchRound.SEMI_FINAL)
+        givenPredictionExists(groupStageMatch, "test-user", 1, 0, points = 3)
+        givenPredictionExists(knockoutMatch, "test-user", 1, 0, points = 5)
+
+        val response = handler(Request(Method.GET, "/league/test-league/leaderboard?stage=KNOCKOUT"))
+        response.status shouldBe Status.OK
+        val body: GetLeagueLeaderboard200Response = response.bodyString().fromJson()
+        body.leaderboard.find { it.user.userId == "test-user" }!!.user.livePoints shouldBe 5
+    }
+
+    @Test
+    fun leaderboardRejectsInvalidStage() {
+        givenLeagueExists("test-league", "Test League")
+        val response = handler(Request(Method.GET, "/league/test-league/leaderboard?stage=NOT_A_STAGE"))
+        response.status shouldBe Status.BAD_REQUEST
     }
 
     @Test


### PR DESCRIPTION
Every league's leaderboard now has All Matches / Group Stage / Knockout
tabs (defaulting to All) that filter points to that stage, computed
on-the-fly from prediction points joined against match round. Also adds
"Group Stage" and "Knockout" as global leagues alongside "Global", which
every member is auto-joined to on signup; existing members are backfilled
via migration.