### PR TITLE
Add predicted vs actual group tables to user history page

### DIFF
--- a/frontend/app/app/user/[userId]/history/page.tsx
+++ b/frontend/app/app/user/[userId]/history/page.tsx
@@ -11,6 +11,7 @@ import {SECTION_EYEBROW} from "@/app/util/css-classes";
 import StreakBadges from "@/app/components/points/streak-badges";
 import {computeStreakStats} from "@/app/util/streaks";
 import {bucketMatchesByGroupLetter, KNOCKOUT_GROUP} from "@/app/util/group-matches";
+import {computePredictedStandings} from "@/app/util/predicted-standings";
 
 export default async function Home({
     params
@@ -64,6 +65,8 @@ export default async function Home({
 
     const streaks = computeStreakStats(games)
     const matchesByGroup = bucketMatchesByGroupLetter(standings.groups, games)
+    const predictedStandingsByGroup = computePredictedStandings(standings.groups, games)
+    const actualStandingsByGroup = Object.fromEntries(standings.groups.map(g => [g.group, g.standings]))
     const groupOrder = [
         ...standings.groups.map(g => g.group).filter(group => matchesByGroup[group]?.length),
         ...(matchesByGroup[KNOCKOUT_GROUP]?.length ? [KNOCKOUT_GROUP] : []),
@@ -156,7 +159,13 @@ export default async function Home({
                 <section className="space-y-4">
                     <h2 className={SECTION_EYEBROW + " text-center"}>Match history</h2>
                     {games.length > 0 ? (
-                        <HistoryGroupFilter matchesByGroup={matchesByGroup} groupOrder={groupOrder} initialGroup={initialGroup}/>
+                        <HistoryGroupFilter
+                            matchesByGroup={matchesByGroup}
+                            groupOrder={groupOrder}
+                            initialGroup={initialGroup}
+                            predictedStandingsByGroup={predictedStandingsByGroup}
+                            actualStandingsByGroup={actualStandingsByGroup}
+                        />
                     ) : (
                         <p className="py-8 text-center text-sm text-slate-500 dark:text-gray-400">No completed matches yet — check back once games have been played.</p>
                     )}

--- a/frontend/app/components/history/history-group-filter.tsx
+++ b/frontend/app/components/history/history-group-filter.tsx
@@ -1,19 +1,25 @@
 'use client'
 
 import React, {useState} from "react"
-import {Match} from "@/client"
+import {GroupStandingRow, Match} from "@/client"
 import HistoryMatchCard from "@/app/components/history/history-match-card"
+import GroupTable from "@/app/components/standings/group-table"
 import {KNOCKOUT_GROUP} from "@/app/util/group-matches"
+import {SECTION_EYEBROW} from "@/app/util/css-classes"
 
 interface HistoryGroupFilterProps {
     matchesByGroup: Record<string, Match[]>
     groupOrder: string[]
     initialGroup?: string
+    predictedStandingsByGroup: Record<string, GroupStandingRow[]>
+    actualStandingsByGroup: Record<string, GroupStandingRow[]>
 }
 
-export default function HistoryGroupFilter({matchesByGroup, groupOrder, initialGroup}: HistoryGroupFilterProps): React.JSX.Element {
+export default function HistoryGroupFilter({matchesByGroup, groupOrder, initialGroup, predictedStandingsByGroup, actualStandingsByGroup}: HistoryGroupFilterProps): React.JSX.Element {
     const [active, setActive] = useState(initialGroup ?? groupOrder[0])
     const matches = matchesByGroup[active] ?? []
+    const predictedStandings = predictedStandingsByGroup[active]
+    const actualStandings = actualStandingsByGroup[active]
 
     return (
         <div className="space-y-4">
@@ -37,6 +43,19 @@ export default function HistoryGroupFilter({matchesByGroup, groupOrder, initialG
                             </button>
                         )
                     })}
+                </div>
+            )}
+
+            {active !== KNOCKOUT_GROUP && predictedStandings && actualStandings && (
+                <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                        <p className={SECTION_EYEBROW + " text-center"}>Your predicted table</p>
+                        <GroupTable group={active} standings={predictedStandings}/>
+                    </div>
+                    <div className="space-y-2">
+                        <p className={SECTION_EYEBROW + " text-center"}>Actual table</p>
+                        <GroupTable group={active} standings={actualStandings}/>
+                    </div>
                 </div>
             )}
 

--- a/frontend/app/util/predicted-standings.ts
+++ b/frontend/app/util/predicted-standings.ts
@@ -1,0 +1,106 @@
+import {GroupStandingRow, Match, MatchRoundEnum, Standings} from "@/client"
+
+interface Accumulator {
+    teamId: string
+    teamName: string
+    flagCode: string
+    group: string
+    played: number
+    won: number
+    drawn: number
+    lost: number
+    goalsFor: number
+    goalsAgainst: number
+    points: number
+}
+
+function rankRows(accumulators: Accumulator[]): GroupStandingRow[] {
+    return [...accumulators]
+        .sort((a, b) =>
+            b.points - a.points
+            || (b.goalsFor - b.goalsAgainst) - (a.goalsFor - a.goalsAgainst)
+            || b.goalsFor - a.goalsFor
+            || a.teamName.localeCompare(b.teamName)
+        )
+        .map((a, index) => ({
+            position: index + 1,
+            teamId: a.teamId,
+            teamName: a.teamName,
+            flagCode: a.flagCode,
+            group: a.group,
+            played: a.played,
+            won: a.won,
+            drawn: a.drawn,
+            lost: a.lost,
+            goalsFor: a.goalsFor,
+            goalsAgainst: a.goalsAgainst,
+            goalDifference: a.goalsFor - a.goalsAgainst,
+            points: a.points,
+        }))
+}
+
+// Builds a per-group table from a user's own score predictions, using the
+// same points/goal-difference rules as the real table but seeded from
+// `match.prediction` instead of the actual result. Teams the user hasn't
+// predicted yet still appear, with all-zero stats, since they come from the
+// real standings' team list rather than from the predicted matches.
+export function computePredictedStandings(groups: Standings["groups"], matches: Match[]): Record<string, GroupStandingRow[]> {
+    const accumulators = new Map<string, Accumulator>()
+    for (const g of groups) {
+        for (const row of g.standings) {
+            accumulators.set(row.teamName.toLowerCase(), {
+                teamId: row.teamId,
+                teamName: row.teamName,
+                flagCode: row.flagCode,
+                group: row.group,
+                played: 0,
+                won: 0,
+                drawn: 0,
+                lost: 0,
+                goalsFor: 0,
+                goalsAgainst: 0,
+                points: 0,
+            })
+        }
+    }
+
+    for (const match of matches) {
+        if (match.round !== MatchRoundEnum.GroupStage) continue
+        const prediction = match.prediction
+        if (!prediction || prediction.homeScore == null || prediction.awayScore == null) continue
+
+        const home = accumulators.get(match.homeTeam.toLowerCase())
+        const away = accumulators.get(match.awayTeam.toLowerCase())
+        if (!home || !away) continue
+
+        const {homeScore, awayScore} = prediction
+        home.played++
+        away.played++
+        home.goalsFor += homeScore
+        home.goalsAgainst += awayScore
+        away.goalsFor += awayScore
+        away.goalsAgainst += homeScore
+
+        if (homeScore > awayScore) {
+            home.won++
+            home.points += 3
+            away.lost++
+        } else if (homeScore < awayScore) {
+            away.won++
+            away.points += 3
+            home.lost++
+        } else {
+            home.drawn++
+            away.drawn++
+            home.points++
+            away.points++
+        }
+    }
+
+    const byGroup: Record<string, Accumulator[]> = {}
+    for (const acc of accumulators.values()) (byGroup[acc.group] ??= []).push(acc)
+
+    const result: Record<string, GroupStandingRow[]> = {}
+    for (const [group, accs] of Object.entries(byGroup)) result[group] = rankRows(accs)
+    return result
+}


### PR DESCRIPTION
Computes per-group standings from a user's own score predictions
(same points/GD rules as the real table) and renders it alongside
the actual table on the history page's group view.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LEFEAquzeXsHTERYtNdVRq