### PR TITLE
Show predicted vs actual group tables with diff arrows

### DIFF
--- a/frontend/app/components/history/history-group-filter.tsx
+++ b/frontend/app/components/history/history-group-filter.tsx
@@ -21,6 +21,16 @@ export default function HistoryGroupFilter({matchesByGroup, groupOrder, initialG
     const predictedStandings = predictedStandingsByGroup[active]
     const actualStandings = actualStandingsByGroup[active]
 
+    // For each team, how its real finish compares to where you predicted it:
+    // positive = it actually finished higher (smaller position) than predicted.
+    const actualPositionByTeam: Record<string, number> = {}
+    for (const row of actualStandings ?? []) actualPositionByTeam[row.teamId] = row.position
+    const predictedDeltas: Record<string, number> = {}
+    for (const row of predictedStandings ?? []) {
+        const actualPosition = actualPositionByTeam[row.teamId]
+        if (actualPosition != null) predictedDeltas[row.teamId] = row.position - actualPosition
+    }
+
     return (
         <div className="space-y-4">
             {groupOrder.length > 1 && (
@@ -47,15 +57,23 @@ export default function HistoryGroupFilter({matchesByGroup, groupOrder, initialG
             )}
 
             {active !== KNOCKOUT_GROUP && predictedStandings && actualStandings && (
-                <div className="grid gap-4 sm:grid-cols-2">
-                    <div className="space-y-2">
-                        <p className={SECTION_EYEBROW + " text-center"}>Your predicted table</p>
-                        <GroupTable group={active} standings={predictedStandings}/>
+                <div className="space-y-2">
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-2">
+                            <p className={SECTION_EYEBROW + " text-center"}>Your predicted table</p>
+                            <GroupTable group={active} standings={predictedStandings} positionDeltas={predictedDeltas}/>
+                        </div>
+                        <div className="space-y-2">
+                            <p className={SECTION_EYEBROW + " text-center"}>Actual table</p>
+                            <GroupTable group={active} standings={actualStandings} showFlags={false}/>
+                        </div>
                     </div>
-                    <div className="space-y-2">
-                        <p className={SECTION_EYEBROW + " text-center"}>Actual table</p>
-                        <GroupTable group={active} standings={actualStandings}/>
-                    </div>
+                    <p className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-center text-[11px] text-slate-500 dark:text-gray-400">
+                        <span>Arrows show each team&apos;s real finish vs your prediction:</span>
+                        <span className="inline-flex items-center gap-1"><span className="font-bold text-emerald-600 dark:text-emerald-400">▲</span> finished higher</span>
+                        <span className="inline-flex items-center gap-1"><span className="font-bold text-rose-600 dark:text-rose-400">▼</span> finished lower</span>
+                        <span className="inline-flex items-center gap-1"><span className="font-bold text-slate-400 dark:text-gray-500">=</span> spot on</span>
+                    </p>
                 </div>
             )}
 

--- a/frontend/app/components/history/history-group-filter.tsx
+++ b/frontend/app/components/history/history-group-filter.tsx
@@ -3,7 +3,7 @@
 import React, {useState} from "react"
 import {GroupStandingRow, Match} from "@/client"
 import HistoryMatchCard from "@/app/components/history/history-match-card"
-import GroupTable from "@/app/components/standings/group-table"
+import PredictionComparisonTable from "@/app/components/history/prediction-comparison-table"
 import {KNOCKOUT_GROUP} from "@/app/util/group-matches"
 import {SECTION_EYEBROW} from "@/app/util/css-classes"
 
@@ -20,16 +20,6 @@ export default function HistoryGroupFilter({matchesByGroup, groupOrder, initialG
     const matches = matchesByGroup[active] ?? []
     const predictedStandings = predictedStandingsByGroup[active]
     const actualStandings = actualStandingsByGroup[active]
-
-    // For each team, how its real finish compares to where you predicted it:
-    // positive = it actually finished higher (smaller position) than predicted.
-    const actualPositionByTeam: Record<string, number> = {}
-    for (const row of actualStandings ?? []) actualPositionByTeam[row.teamId] = row.position
-    const predictedDeltas: Record<string, number> = {}
-    for (const row of predictedStandings ?? []) {
-        const actualPosition = actualPositionByTeam[row.teamId]
-        if (actualPosition != null) predictedDeltas[row.teamId] = row.position - actualPosition
-    }
 
     return (
         <div className="space-y-4">
@@ -58,21 +48,13 @@ export default function HistoryGroupFilter({matchesByGroup, groupOrder, initialG
 
             {active !== KNOCKOUT_GROUP && predictedStandings && actualStandings && (
                 <div className="space-y-2">
-                    <div className="grid gap-4 sm:grid-cols-2">
-                        <div className="space-y-2">
-                            <p className={SECTION_EYEBROW + " text-center"}>Your predicted table</p>
-                            <GroupTable group={active} standings={predictedStandings} positionDeltas={predictedDeltas}/>
-                        </div>
-                        <div className="space-y-2">
-                            <p className={SECTION_EYEBROW + " text-center"}>Actual table</p>
-                            <GroupTable group={active} standings={actualStandings} showFlags={false}/>
-                        </div>
-                    </div>
+                    <p className={SECTION_EYEBROW + " text-center"}>Final table vs your prediction</p>
+                    <PredictionComparisonTable group={active} actualStandings={actualStandings} predictedStandings={predictedStandings}/>
                     <p className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-center text-[11px] text-slate-500 dark:text-gray-400">
-                        <span>Arrows show each team&apos;s real finish vs your prediction:</span>
+                        <span><span className="font-semibold text-slate-600 dark:text-gray-300">Your call</span> = where you predicted each team.</span>
                         <span className="inline-flex items-center gap-1"><span className="font-bold text-emerald-600 dark:text-emerald-400">▲</span> finished higher</span>
                         <span className="inline-flex items-center gap-1"><span className="font-bold text-rose-600 dark:text-rose-400">▼</span> finished lower</span>
-                        <span className="inline-flex items-center gap-1"><span className="font-bold text-slate-400 dark:text-gray-500">=</span> spot on</span>
+                        <span className="inline-flex items-center gap-1"><span className="font-bold text-emerald-600 dark:text-emerald-400">✓</span> spot on</span>
                     </p>
                 </div>
             )}

--- a/frontend/app/components/history/prediction-comparison-table.tsx
+++ b/frontend/app/components/history/prediction-comparison-table.tsx
@@ -57,13 +57,11 @@ export default function PredictionComparisonTable({group, actualStandings, predi
                         <tr className="text-[11px] uppercase tracking-wider text-slate-400 dark:text-gray-500">
                             <th className="py-1.5 pl-4 pr-1 text-left font-semibold">#</th>
                             <th className="py-1.5 px-1 text-left font-semibold">Team</th>
-                            <th className="py-1.5 px-1 text-center font-semibold">Your call</th>
-                            <th className="py-1.5 px-1 text-center font-semibold w-7">P</th>
                             <th className="py-1.5 px-1 text-center font-semibold w-7 hidden sm:table-cell">W</th>
                             <th className="py-1.5 px-1 text-center font-semibold w-7 hidden sm:table-cell">D</th>
                             <th className="py-1.5 px-1 text-center font-semibold w-7 hidden sm:table-cell">L</th>
-                            <th className="py-1.5 px-1 text-center font-semibold w-9">GD</th>
-                            <th className="py-1.5 pl-1 pr-4 text-center font-semibold w-9">Pts</th>
+                            <th className="py-1.5 px-1 text-center font-semibold w-9">Pts</th>
+                            <th className="py-1.5 pl-1 pr-4 text-center font-semibold">Your call</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -84,7 +82,11 @@ export default function PredictionComparisonTable({group, actualStandings, predi
                                             <span className="truncate font-semibold text-slate-800 dark:text-gray-100">{row.teamName}</span>
                                         </span>
                                     </td>
-                                    <td className="py-2 px-1">
+                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.won}</td>
+                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.drawn}</td>
+                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.lost}</td>
+                                    <td className="py-2 px-1 text-center tabular-nums font-black text-slate-900 dark:text-white">{row.points}</td>
+                                    <td className="py-2 pl-1 pr-4">
                                         <span className="flex items-center justify-center gap-1.5">
                                             <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-slate-900/5 px-1 text-xs font-bold tabular-nums text-slate-600 dark:bg-white/10 dark:text-gray-300">
                                                 {predicted ?? "–"}
@@ -92,12 +94,6 @@ export default function PredictionComparisonTable({group, actualStandings, predi
                                             {delta != null && <CallDelta delta={delta}/>}
                                         </span>
                                     </td>
-                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300">{row.played}</td>
-                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.won}</td>
-                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.drawn}</td>
-                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.lost}</td>
-                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300">{row.goalDifference > 0 ? `+${row.goalDifference}` : row.goalDifference}</td>
-                                    <td className="py-2 pl-1 pr-4 text-center tabular-nums font-black text-slate-900 dark:text-white">{row.points}</td>
                                 </tr>
                             )
                         })}

--- a/frontend/app/components/history/prediction-comparison-table.tsx
+++ b/frontend/app/components/history/prediction-comparison-table.tsx
@@ -1,0 +1,109 @@
+import React from "react"
+import {GroupStandingRow} from "@/client"
+import {FlagImage} from "@/app/components/predictions/flag-image"
+import {positionAccent, positionDot} from "@/app/components/standings/group-table"
+
+/**
+ * Diff arrow for the "Your call" column. `delta` is `predictedPosition -
+ * actualPosition`, so a positive value means the team finished higher (a
+ * smaller position number) than the user predicted — an up arrow.
+ */
+function CallDelta({delta}: {delta: number}): React.JSX.Element {
+    if (delta === 0) {
+        return (
+            <span title="Exactly as you predicted" className="shrink-0 text-[11px] font-bold leading-none text-emerald-600 dark:text-emerald-400">✓</span>
+        )
+    }
+    const up = delta > 0
+    return (
+        <span
+            title={`Finished ${Math.abs(delta)} place${Math.abs(delta) === 1 ? "" : "s"} ${up ? "higher" : "lower"} than you predicted`}
+            className={`inline-flex shrink-0 items-center gap-px text-[11px] font-bold leading-none tabular-nums ${
+                up ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"
+            }`}
+        >
+            <span aria-hidden>{up ? "▲" : "▼"}</span>{Math.abs(delta)}
+        </span>
+    )
+}
+
+interface PredictionComparisonTableProps {
+    group: string
+    actualStandings: GroupStandingRow[]
+    predictedStandings: GroupStandingRow[]
+}
+
+/**
+ * A single table that merges a user's predicted group table with the real one.
+ * Rows follow the actual final standings; the "Your call" column shows where
+ * the user predicted each team, with an arrow for how far reality differed.
+ */
+export default function PredictionComparisonTable({group, actualStandings, predictedStandings}: PredictionComparisonTableProps): React.JSX.Element {
+    const predictedPositionByTeam: Record<string, number> = {}
+    for (const row of predictedStandings) predictedPositionByTeam[row.teamId] = row.position
+
+    return (
+        <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-xl shadow-slate-900/5 dark:shadow-cyan-500/5">
+            <div className="rounded-3xl bg-white/70 dark:bg-white/[0.03] backdrop-blur-sm overflow-hidden">
+                <div className="flex items-center gap-2 px-4 pt-4 pb-2">
+                    <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 via-cyan-400 to-teal-300 text-sm font-black text-white">
+                        {group}
+                    </span>
+                    <span className="text-sm font-bold text-slate-700 dark:text-gray-200">Group {group}</span>
+                    <span className="ml-auto text-[10px] font-bold uppercase tracking-wider text-slate-400 dark:text-gray-500">Final vs your call</span>
+                </div>
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="text-[11px] uppercase tracking-wider text-slate-400 dark:text-gray-500">
+                            <th className="py-1.5 pl-4 pr-1 text-left font-semibold">#</th>
+                            <th className="py-1.5 px-1 text-left font-semibold">Team</th>
+                            <th className="py-1.5 px-1 text-center font-semibold">Your call</th>
+                            <th className="py-1.5 px-1 text-center font-semibold w-7">P</th>
+                            <th className="py-1.5 px-1 text-center font-semibold w-7 hidden sm:table-cell">W</th>
+                            <th className="py-1.5 px-1 text-center font-semibold w-7 hidden sm:table-cell">D</th>
+                            <th className="py-1.5 px-1 text-center font-semibold w-7 hidden sm:table-cell">L</th>
+                            <th className="py-1.5 px-1 text-center font-semibold w-9">GD</th>
+                            <th className="py-1.5 pl-1 pr-4 text-center font-semibold w-9">Pts</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {actualStandings.map(row => {
+                            const predicted = predictedPositionByTeam[row.teamId]
+                            const delta = predicted != null ? predicted - row.position : undefined
+                            return (
+                                <tr key={row.teamId} className={`border-t border-slate-900/5 dark:border-white/5 ${positionAccent(row.position)}`}>
+                                    <td className="py-2 pl-4 pr-1">
+                                        <span className="flex items-center gap-1.5">
+                                            <span className={`h-1.5 w-1.5 rounded-full ${positionDot(row.position)}`}/>
+                                            <span className="text-xs font-semibold text-slate-500 dark:text-gray-400">{row.position}</span>
+                                        </span>
+                                    </td>
+                                    <td className="py-2 px-1">
+                                        <span className="flex items-center gap-2 min-w-0">
+                                            <FlagImage code={row.flagCode} name={row.teamName} size={22}/>
+                                            <span className="truncate font-semibold text-slate-800 dark:text-gray-100">{row.teamName}</span>
+                                        </span>
+                                    </td>
+                                    <td className="py-2 px-1">
+                                        <span className="flex items-center justify-center gap-1.5">
+                                            <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-slate-900/5 px-1 text-xs font-bold tabular-nums text-slate-600 dark:bg-white/10 dark:text-gray-300">
+                                                {predicted ?? "–"}
+                                            </span>
+                                            {delta != null && <CallDelta delta={delta}/>}
+                                        </span>
+                                    </td>
+                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300">{row.played}</td>
+                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.won}</td>
+                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.drawn}</td>
+                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300 hidden sm:table-cell">{row.lost}</td>
+                                    <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300">{row.goalDifference > 0 ? `+${row.goalDifference}` : row.goalDifference}</td>
+                                    <td className="py-2 pl-1 pr-4 text-center tabular-nums font-black text-slate-900 dark:text-white">{row.points}</td>
+                                </tr>
+                            )
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    )
+}

--- a/frontend/app/components/standings/group-table.tsx
+++ b/frontend/app/components/standings/group-table.tsx
@@ -6,53 +6,19 @@ import {FlagImage} from "@/app/components/predictions/flag-image"
  * Background tint for a row based on where the team sits. Top two qualify for
  * the knockouts directly; third place may still go through as a best third.
  */
-function positionAccent(position: number): string {
+export function positionAccent(position: number): string {
     if (position <= 2) return "bg-emerald-500/10 dark:bg-emerald-400/10"
     if (position === 3) return "bg-amber-500/10 dark:bg-amber-400/10"
     return ""
 }
 
-function positionDot(position: number): string {
+export function positionDot(position: number): string {
     if (position <= 2) return "bg-emerald-500"
     if (position === 3) return "bg-amber-500"
     return "bg-slate-300 dark:bg-white/20"
 }
 
-/**
- * Small arrow showing how a team's real finish differs from where it sits in
- * this table. `delta` is `thisTablePosition - actualPosition`, so a positive
- * value means the team actually finished higher (a smaller position number)
- * than shown here — an up arrow.
- */
-function PositionDelta({delta}: {delta: number}): React.JSX.Element {
-    if (delta === 0) {
-        return (
-            <span title="Exactly as you predicted" className="shrink-0 text-[11px] font-bold leading-none text-slate-400 dark:text-gray-500">=</span>
-        )
-    }
-    const up = delta > 0
-    return (
-        <span
-            title={`Actually finished ${Math.abs(delta)} place${Math.abs(delta) === 1 ? "" : "s"} ${up ? "higher" : "lower"}`}
-            className={`inline-flex shrink-0 items-center gap-px text-[11px] font-bold leading-none tabular-nums ${
-                up ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"
-            }`}
-        >
-            <span aria-hidden>{up ? "▲" : "▼"}</span>{Math.abs(delta)}
-        </span>
-    )
-}
-
-interface GroupTableProps {
-    group: string
-    standings: GroupStandingRow[]
-    /** Show country flags next to team names (default true). */
-    showFlags?: boolean
-    /** Per-team `thisTablePosition - actualPosition`, rendered as a diff arrow. */
-    positionDeltas?: Record<string, number>
-}
-
-export default function GroupTable({group, standings, showFlags = true, positionDeltas}: GroupTableProps): React.JSX.Element {
+export default function GroupTable({group, standings}: {group: string; standings: GroupStandingRow[]}): React.JSX.Element {
     return (
         <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-xl shadow-slate-900/5 dark:shadow-cyan-500/5">
             <div className="rounded-3xl bg-white/70 dark:bg-white/[0.03] backdrop-blur-sm overflow-hidden">
@@ -86,9 +52,8 @@ export default function GroupTable({group, standings, showFlags = true, position
                                 </td>
                                 <td className="py-2 px-1">
                                     <span className="flex items-center gap-2 min-w-0">
-                                        {showFlags && <FlagImage code={row.flagCode} name={row.teamName} size={22}/>}
+                                        <FlagImage code={row.flagCode} name={row.teamName} size={22}/>
                                         <span className="truncate font-semibold text-slate-800 dark:text-gray-100">{row.teamName}</span>
-                                        {positionDeltas && <PositionDelta delta={positionDeltas[row.teamId] ?? 0}/>}
                                     </span>
                                 </td>
                                 <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300">{row.played}</td>

--- a/frontend/app/components/standings/group-table.tsx
+++ b/frontend/app/components/standings/group-table.tsx
@@ -18,7 +18,41 @@ function positionDot(position: number): string {
     return "bg-slate-300 dark:bg-white/20"
 }
 
-export default function GroupTable({group, standings}: {group: string; standings: GroupStandingRow[]}): React.JSX.Element {
+/**
+ * Small arrow showing how a team's real finish differs from where it sits in
+ * this table. `delta` is `thisTablePosition - actualPosition`, so a positive
+ * value means the team actually finished higher (a smaller position number)
+ * than shown here — an up arrow.
+ */
+function PositionDelta({delta}: {delta: number}): React.JSX.Element {
+    if (delta === 0) {
+        return (
+            <span title="Exactly as you predicted" className="shrink-0 text-[11px] font-bold leading-none text-slate-400 dark:text-gray-500">=</span>
+        )
+    }
+    const up = delta > 0
+    return (
+        <span
+            title={`Actually finished ${Math.abs(delta)} place${Math.abs(delta) === 1 ? "" : "s"} ${up ? "higher" : "lower"}`}
+            className={`inline-flex shrink-0 items-center gap-px text-[11px] font-bold leading-none tabular-nums ${
+                up ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"
+            }`}
+        >
+            <span aria-hidden>{up ? "▲" : "▼"}</span>{Math.abs(delta)}
+        </span>
+    )
+}
+
+interface GroupTableProps {
+    group: string
+    standings: GroupStandingRow[]
+    /** Show country flags next to team names (default true). */
+    showFlags?: boolean
+    /** Per-team `thisTablePosition - actualPosition`, rendered as a diff arrow. */
+    positionDeltas?: Record<string, number>
+}
+
+export default function GroupTable({group, standings, showFlags = true, positionDeltas}: GroupTableProps): React.JSX.Element {
     return (
         <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-xl shadow-slate-900/5 dark:shadow-cyan-500/5">
             <div className="rounded-3xl bg-white/70 dark:bg-white/[0.03] backdrop-blur-sm overflow-hidden">
@@ -52,8 +86,9 @@ export default function GroupTable({group, standings}: {group: string; standings
                                 </td>
                                 <td className="py-2 px-1">
                                     <span className="flex items-center gap-2 min-w-0">
-                                        <FlagImage code={row.flagCode} name={row.teamName} size={22}/>
+                                        {showFlags && <FlagImage code={row.flagCode} name={row.teamName} size={22}/>}
                                         <span className="truncate font-semibold text-slate-800 dark:text-gray-100">{row.teamName}</span>
+                                        {positionDeltas && <PositionDelta delta={positionDeltas[row.teamId] ?? 0}/>}
                                     </span>
                                 </td>
                                 <td className="py-2 px-1 text-center tabular-nums text-slate-600 dark:text-gray-300">{row.played}</td>


### PR DESCRIPTION
Improve the user history page's group standings comparison:
- Add per-team diff arrows in the predicted table showing how each team's
  real finish compares to where it was predicted (▲ higher, ▼ lower, = spot on).
- Drop flags from the actual table so flags only appear in the predicted
  table, reducing visual repetition between the two side-by-side tables.
- Add a small legend explaining the arrows.

GroupTable gains optional showFlags and positionDeltas props, defaulting
to the previous behaviour so the main standings page is unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VMcKcX3jKinVYfZroGeyZH