### PR TITLE
Polish app chrome: sticky frosted headers, entrance motion, unified surfaces

### DIFF
--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -11,6 +11,8 @@ import { Toaster } from "react-hot-toast";
 import AdminButton from "@/app/components/admin-button";
 import ThemeToggle from "@/app/components/theme-toggle";
 import SectionHeading from "@/app/components/section-heading";
+import Wordmark from "@/app/components/wordmark";
+import SurfaceCard from "@/app/components/surface-card";
 import {PitchPerspective} from "@/app/components/atmosphere";
 import LeaguesHelp from "@/app/components/leaderboard/leagues-help";
 import MatchesHelp from "@/app/components/predictions/matches-help";
@@ -65,19 +67,13 @@ const Home = async ({searchParams}: {searchParams: Promise<Record<string, string
     const firstMatchId = (liveMatches[0] ?? firstUnpredictedUpcoming ?? upcomingMatches[0])?.matchId
 
     return (
-        <main className="relative min-h-screen bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-x-hidden">
+        <main className="relative min-h-screen bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-x-clip">
             <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.08),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.05),transparent_60%)] dark:bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.15),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.10),transparent_60%)]"/>
             <div className="pointer-events-none absolute inset-x-0 bottom-0 h-svh"><PitchPerspective/></div>
 
             <div className="relative w-full max-w-screen-lg mx-auto px-4 sm:px-6 py-6 space-y-10">
-                <Toaster />
-
-                <header className="flex items-center justify-between">
-                    <Link href="/" className="flex items-baseline font-black tracking-tight text-lg">
-                        <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">predicta</span>
-                        <span className="text-slate-900 dark:text-white">ball</span>
-                        <span className="ml-0.5 text-[10px] font-medium tracking-[0.2em] text-slate-500 dark:text-gray-400">.LIVE</span>
-                    </Link>
+                <header className="sticky top-0 z-40 -mx-4 sm:-mx-6 -mt-6 px-4 sm:px-6 py-3 flex items-center justify-between border-b border-slate-200/60 bg-slate-50/75 backdrop-blur-md dark:border-white/5 dark:bg-gray-900/75">
+                    <Wordmark/>
                     <div className="flex items-center gap-2">
                         <ThemeToggle sizeClassName="h-8 w-8" />
                         <AdminButton />
@@ -95,12 +91,16 @@ const Home = async ({searchParams}: {searchParams: Promise<Record<string, string
                     </div>
                 </header>
 
+                <Toaster />
+
                 <MatchSelectionProvider initialId={firstMatchId}>
                     <PredictNowBanner upcomingMatches={upcomingMatches} />
 
-                    <HeadlineSuspense tournamentStarted={tournamentStarted} nextKickoff={tournamentState?.nextKickoff} hasLiveMatch={liveMatches.length > 0} supportedTeamId={profile?.supportedTeamId} streaks={streaks} />
+                    <div className="animate-fade-rise motion-reduce:animate-none">
+                        <HeadlineSuspense tournamentStarted={tournamentStarted} nextKickoff={tournamentState?.nextKickoff} hasLiveMatch={liveMatches.length > 0} supportedTeamId={profile?.supportedTeamId} streaks={streaks} />
+                    </div>
 
-                    <section id="matches" className="space-y-4">
+                    <section id="matches" className="space-y-4 animate-fade-rise animation-delay-75 motion-reduce:animate-none">
                         <SectionHeading
                             title="Matches"
                             count={liveMatches.length + upcomingMatches.length}
@@ -116,16 +116,14 @@ const Home = async ({searchParams}: {searchParams: Promise<Record<string, string
                     <PredictionPanel liveMatches={liveMatches} upcomingMatches={upcomingMatches} completedMatches={recentCompleted} historyHref={historyHref} userChips={userChips} streaks={streaks} />
                 </section>
 
-                <section className="space-y-4">
+                <section className="space-y-4 animate-fade-rise animation-delay-150 motion-reduce:animate-none">
                     <SectionHeading title="Your Leagues" count={leagues.length} action={<LeaguesHelp/>}/>
-                    <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-xl shadow-slate-900/5 dark:shadow-cyan-500/5">
-                        <div className="rounded-3xl bg-white/60 dark:bg-white/[0.03] backdrop-blur-sm p-5 sm:p-6">
-                            <Dashboard initialLeagues={leagues} />
-                        </div>
-                    </div>
+                    <SurfaceCard>
+                        <Dashboard initialLeagues={leagues} />
+                    </SurfaceCard>
                 </section>
 
-                <section className="space-y-4">
+                <section className="space-y-4 animate-fade-rise animation-delay-300 motion-reduce:animate-none">
                     <SectionHeading
                         title="Global standing"
                         action={
@@ -134,14 +132,12 @@ const Home = async ({searchParams}: {searchParams: Promise<Record<string, string
                             </Link>
                         }
                     />
-                    <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-xl shadow-slate-900/5 dark:shadow-cyan-500/5">
-                        <div className="rounded-3xl bg-white/60 dark:bg-white/[0.03] backdrop-blur-sm p-5 sm:p-6">
-                            <Leaderboard shouldPaginate={false} leagueId={"global"} limit={true} />
-                        </div>
-                    </div>
+                    <SurfaceCard>
+                        <Leaderboard shouldPaginate={false} leagueId={"global"} limit={true} />
+                    </SurfaceCard>
                 </section>
 
-                <section className="space-y-4 pb-10">
+                <section className="space-y-4 pb-10 animate-fade-rise animation-delay-500 motion-reduce:animate-none">
                     <SectionHeading
                         title="Country rankings"
                         action={
@@ -150,13 +146,11 @@ const Home = async ({searchParams}: {searchParams: Promise<Record<string, string
                             </Link>
                         }
                     />
-                    <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-xl shadow-slate-900/5 dark:shadow-cyan-500/5">
-                        <div className="rounded-3xl bg-white/60 dark:bg-white/[0.03] backdrop-blur-sm p-5 sm:p-6">
-                            <Suspense fallback={<LeaderboardSkeleton/>}>
-                                <CountryRankingsPreview limit={5}/>
-                            </Suspense>
-                        </div>
-                    </div>
+                    <SurfaceCard>
+                        <Suspense fallback={<LeaderboardSkeleton/>}>
+                            <CountryRankingsPreview limit={5}/>
+                        </Suspense>
+                    </SurfaceCard>
                 </section>
                 </MatchSelectionProvider>
             </div>

--- a/frontend/app/app/profile/page.tsx
+++ b/frontend/app/app/profile/page.tsx
@@ -1,10 +1,9 @@
 import React from "react"
-import Link from "next/link"
 import { Toaster } from "react-hot-toast"
 import { getConfigWithAuthHeader } from "@/app/api/client-config"
 import { UserApi } from "@/client"
 import { FlagImage } from "@/app/components/predictions/flag-image"
-import BackButton from "@/app/components/back-button"
+import PageHeader from "@/app/components/page-header"
 import RemindersToggle from "@/app/components/profile/reminders-toggle"
 import EditProfileButton from "@/app/components/profile/edit-profile-button"
 import { SECTION_EYEBROW } from "@/app/util/css-classes"
@@ -14,21 +13,13 @@ export default async function ProfilePage(): Promise<React.JSX.Element> {
     const profile = await userApi.getUserProfile().catch(() => null)
 
     return (
-        <main className="relative min-h-screen bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-x-hidden">
+        <main className="relative min-h-screen bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-x-clip">
             <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.08),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.05),transparent_60%)] dark:bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.15),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.10),transparent_60%)]"/>
 
             <div className="relative w-full max-w-lg mx-auto px-4 sm:px-6 py-6 space-y-8">
                 <Toaster />
 
-                <header className="relative flex items-center justify-between">
-                    <BackButton/>
-                    <Link href="/" className="hidden sm:flex items-baseline font-black tracking-tight text-lg absolute left-1/2 -translate-x-1/2">
-                        <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">predicta</span>
-                        <span className="text-slate-900 dark:text-white">ball</span>
-                        <span className="ml-0.5 text-[10px] font-medium tracking-[0.2em] text-slate-500 dark:text-gray-400">.LIVE</span>
-                    </Link>
-                    <div className="w-10"/>
-                </header>
+                <PageHeader/>
 
                 {!profile && (
                     <p className="text-sm text-slate-600 dark:text-gray-300">

--- a/frontend/app/app/standings/page.tsx
+++ b/frontend/app/app/standings/page.tsx
@@ -1,6 +1,5 @@
 import React from "react"
-import Link from "next/link"
-import BackButton from "@/app/components/back-button"
+import PageHeader from "@/app/components/page-header"
 import {getConfigWithAuthHeader} from "@/app/api/client-config"
 import {ListMatchesFilterTypeEnum, Match, MatchApi, MatchRoundEnum, Standings, StandingsApi} from "@/client"
 import {PitchPerspective} from "@/app/components/atmosphere"
@@ -67,22 +66,14 @@ export default async function StandingsPage(
     const matchesByGroup = bucketMatchesByGroup(standings.groups, [...liveMatches, ...upcomingMatches, ...completedMatches])
 
     return (
-        <main className="relative min-h-svh bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-x-hidden">
+        <main className="relative min-h-svh bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-x-clip">
             <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.08),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.05),transparent_60%)] dark:bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.15),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.10),transparent_60%)]"/>
             <div className="pointer-events-none absolute inset-x-0 top-0 h-svh"><PitchPerspective/></div>
 
             {hasLiveMatch && <StandingsRefresher/>}
 
             <div className="relative w-full max-w-5xl mx-auto px-4 sm:px-6 py-6 space-y-6">
-                <header className="relative flex items-center justify-between gap-3">
-                    <BackButton/>
-                    <Link href="/" className="hidden sm:flex items-baseline font-black tracking-tight text-lg absolute left-1/2 -translate-x-1/2">
-                        <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">predicta</span>
-                        <span className="text-slate-900 dark:text-white">ball</span>
-                        <span className="ml-0.5 text-[10px] font-medium tracking-[0.2em] text-slate-500 dark:text-gray-400">.LIVE</span>
-                    </Link>
-                    <div className="w-10"/>
-                </header>
+                <PageHeader/>
 
                 <div className="flex flex-col items-center text-center">
                     <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500 via-cyan-400 to-teal-300 shadow-lg shadow-cyan-500/30">

--- a/frontend/app/app/user/[userId]/history/page.tsx
+++ b/frontend/app/app/user/[userId]/history/page.tsx
@@ -2,8 +2,7 @@ import {getConfigWithAuthHeader} from "@/app/api/client-config"
 import HistoryGroupFilter from "@/app/components/history/history-group-filter"
 import HistoryMatchCard from "@/app/components/history/history-match-card"
 import {LeaderboardInner, LeagueApi, ListMatchesFilterTypeEnum, Match, MatchApi, Standings, StandingsApi} from "@/client"
-import BackButton from "@/app/components/back-button";
-import Link from "next/link";
+import PageHeader from "@/app/components/page-header";
 import React from "react";
 import {getUserForm} from "@/app/components/leaderboard/get-user-form";
 import {FlagImage} from "@/app/components/predictions/flag-image";
@@ -88,19 +87,11 @@ export default async function Home({
     const totalPoints = user ? user.fixedPoints + user.livePoints : undefined
 
     return (
-        <main className="relative min-h-svh bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-x-hidden">
+        <main className="relative min-h-svh bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-x-clip">
             <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.08),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.05),transparent_60%)] dark:bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.15),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.10),transparent_60%)]"/>
 
             <div className="relative w-full max-w-3xl mx-auto px-4 sm:px-6 py-6 space-y-8">
-                <header className="relative flex items-center justify-between">
-                    <BackButton/>
-                    <Link href="/" className="hidden sm:flex items-baseline font-black tracking-tight text-lg absolute left-1/2 -translate-x-1/2">
-                        <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">predicta</span>
-                        <span className="text-slate-900 dark:text-white">ball</span>
-                        <span className="ml-0.5 text-[10px] font-medium tracking-[0.2em] text-slate-500 dark:text-gray-400">.LIVE</span>
-                    </Link>
-                    <div className="w-10"/>
-                </header>
+                <PageHeader/>
 
                 <section className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
                     <div className="flex items-center gap-4">

--- a/frontend/app/components/back-button.tsx
+++ b/frontend/app/components/back-button.tsx
@@ -11,7 +11,7 @@ export default function BackButton(): React.JSX.Element {
     const router = useRouter()
 
     return (
-        <Button isIconOnly radius="full" className={BRAND_GHOST_BUTTON_CLASS} onPress={() => router.push("/app")}>
+        <Button isIconOnly aria-label="Back to app" radius="full" className={BRAND_GHOST_BUTTON_CLASS} onPress={() => router.push("/app")}>
             <BackIcon/>
         </Button>
     )

--- a/frontend/app/components/page-header.tsx
+++ b/frontend/app/components/page-header.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import BackButton from "@/app/components/back-button"
+import Wordmark from "@/app/components/wordmark"
+
+/**
+ * Shared header for every authenticated sub-page (history, standings, profile):
+ * a back button on the left, the wordmark centred, and a matching spacer so the
+ * wordmark stays optically centred. It sticks to the top of the viewport behind
+ * a translucent, blurred bar so content scrolls cleanly underneath — the same
+ * frosted-chrome treatment used on the main app screen.
+ *
+ * The negative inline margins let the frosted bar bleed to the edges of the
+ * page's content column while the inner row keeps the column's padding.
+ */
+export default function PageHeader(): React.JSX.Element {
+    return (
+        <header className="sticky top-0 z-40 -mx-4 sm:-mx-6 -mt-6 px-4 sm:px-6 py-3 border-b border-slate-200/60 bg-slate-50/75 backdrop-blur-md dark:border-white/5 dark:bg-gray-900/75">
+            <div className="relative flex items-center justify-between">
+                <BackButton/>
+                <Wordmark className="hidden sm:flex absolute left-1/2 -translate-x-1/2"/>
+                <div className="w-10"/>
+            </div>
+        </header>
+    )
+}

--- a/frontend/app/components/section-heading.tsx
+++ b/frontend/app/components/section-heading.tsx
@@ -11,6 +11,9 @@ export default function SectionHeading({title, count, action}: SectionHeadingPro
     return (
         <div className="flex items-center justify-between gap-3 px-1">
             <div className="flex items-center gap-2">
+                {/* Slim gradient tick anchors each section heading to the brand
+                    palette and gives the understated eyebrow a touch more intent. */}
+                <span aria-hidden className="h-3.5 w-1 rounded-full bg-gradient-to-b from-blue-500 via-cyan-400 to-teal-300"/>
                 <h2 className={SECTION_EYEBROW}>{title}</h2>
                 {count !== undefined && (
                     <span className="rounded-full bg-slate-900/5 dark:bg-white/10 px-2 py-0.5 text-[11px] font-bold tabular-nums text-slate-500 dark:text-gray-400">

--- a/frontend/app/components/surface-card.tsx
+++ b/frontend/app/components/surface-card.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+
+interface SurfaceCardProps {
+    children: React.ReactNode
+    /** Extra classes for the outer gradient-border frame. */
+    className?: string
+    /** Extra classes for the inner panel (e.g. padding overrides). */
+    innerClassName?: string
+}
+
+/**
+ * The app's signature surface: a hairline gradient "border" (a 1px-padded
+ * gradient frame) wrapping a frosted panel. Centralised here so every elevated
+ * card — leagues, leaderboards, group tables — shares the exact same depth,
+ * radius and glow, and so the treatment can be tuned in one place.
+ *
+ * A gentle shadow lift on hover gives the cards a touch of life without
+ * implying the whole surface is a single tap target.
+ */
+export default function SurfaceCard({children, className = "", innerClassName = ""}: SurfaceCardProps): React.JSX.Element {
+    return (
+        <div className={`relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 p-[1px] shadow-xl shadow-slate-900/5 transition-shadow duration-300 hover:shadow-2xl hover:shadow-cyan-500/10 dark:from-white/15 dark:to-white/5 dark:shadow-cyan-500/5 dark:hover:shadow-cyan-500/15 ${className}`}>
+            <div className={`rounded-3xl bg-white/60 backdrop-blur-sm dark:bg-white/[0.03] ${innerClassName || "p-5 sm:p-6"}`}>
+                {children}
+            </div>
+        </div>
+    )
+}

--- a/frontend/app/components/wordmark.tsx
+++ b/frontend/app/components/wordmark.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import Link from "next/link"
+
+interface WordmarkProps {
+    /** Extra classes for positioning (e.g. absolute-centering on sub-pages). */
+    className?: string
+}
+
+/**
+ * The predicta·ball·.LIVE wordmark. Single source of truth so the gradient,
+ * weights and the .LIVE suffix stay identical everywhere it appears (app header,
+ * every sub-page header, etc.).
+ */
+export default function Wordmark({className = ""}: WordmarkProps): React.JSX.Element {
+    return (
+        <Link href="/" className={`flex items-baseline font-black tracking-tight text-lg ${className}`}>
+            <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">predicta</span>
+            <span className="text-slate-900 dark:text-white">ball</span>
+            <span className="ml-0.5 text-[10px] font-medium tracking-[0.2em] text-slate-500 dark:text-gray-400">.LIVE</span>
+        </Link>
+    )
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -28,12 +28,20 @@ const config: Config = {
                 fastpulse: 'pulsing 1s linear infinite',
                 scroll: 'scroll 55s linear infinite',
                 scrollReverse: 'scrollReverse 45s linear infinite',
-                gradient: 'gradient 6s ease infinite'
+                gradient: 'gradient 6s ease infinite',
+                // Section entrance: fade up into place. `both` fill keeps the
+                // element hidden through any animation-delay (no flash) and
+                // pinned in place once it lands.
+                'fade-rise': 'fade-rise 0.5s cubic-bezier(0.22, 1, 0.36, 1) both',
             },
             keyframes: {
                 wiggle: {
                     '0%, 100%': {transform: 'rotate(-3deg)'},
                     '50%': {transform: 'rotate(3deg)'},
+                },
+                'fade-rise': {
+                    '0%': {opacity: '0', transform: 'translateY(14px)'},
+                    '100%': {opacity: '1', transform: 'translateY(0)'},
                 },
                 slide: {
                     '0%': {


### PR DESCRIPTION
## What & why

A UI polish pass across the authenticated surfaces — home, user history, standings, and profile — to push the app toward a more premium, "award-winning" feel **without changing the visual language** (same palette, same gradient-border cards, same typography).

## Changes

### Sticky, frosted app chrome
- New **`Wordmark`** component — single source of truth for the `predicta·ball·.LIVE` logo, which was copy-pasted across four pages.
- New **`PageHeader`** — a sticky, translucent `backdrop-blur` sub-page header (back button + centred wordmark). Adopted by **history**, **standings**, and **profile**, replacing three hand-rolled copies.
- The **home** header is now sticky and frosted too, using `Wordmark`.
- **Key fix:** switched the affected pages from `overflow-x-hidden` → `overflow-x-clip`. `overflow-x: hidden` silently promotes the page to a non-scrolling scroll-container, which **breaks `position: sticky`**. `clip` prevents horizontal overflow (from the globe/decorations) without that side effect, so the sticky headers actually pin to the viewport.

### Entrance motion (home)
- Sections fade-and-rise into place with a stagger (`headline → matches → leagues → global → countries`) via a new `fade-rise` keyframe.
- Gated behind `motion-reduce:animate-none`, so users who prefer reduced motion are unaffected. `both` fill-mode means no flash during the stagger delay.

### Unified surfaces
- New **`SurfaceCard`** centralises the signature gradient-border frosted card (previously duplicated inline) and adds a gentle hover-depth lift. Used for the home Leagues / Global standing / Country rankings cards.

### Smaller polish
- `SectionHeading` gains a slim brand-gradient tick for stronger hierarchy.
- `BackButton` gets an `aria-label` (the one icon-only button that was missing an accessible name).

## Testing
- `tsc --noEmit` is clean for all changed files (the only remaining errors are the pre-existing missing build-time-generated `@/client` module, which CI generates via `prebuild`).
- Verified Tailwind compiles the new utilities (`animate-fade-rise`, `animation-delay-*`, `motion-reduce:animate-none`, `overflow-x-clip`) with the expected `both` fill-mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtcuCMR7MnKEPokMKmHWfu)_