### PR TITLE
Remove venue map from standings page

### DIFF
--- a/frontend/app/components/standings/standings-groups.tsx
+++ b/frontend/app/components/standings/standings-groups.tsx
@@ -4,7 +4,6 @@ import React, {useState} from "react"
 import {useRouter} from "next/navigation"
 import {GroupStanding} from "@/client"
 import GroupTable from "@/app/components/standings/group-table"
-import GroupVenueMap from "@/app/components/flags/group-venue-map"
 import type {GroupMatch} from "@/app/components/flags/group-venue-map"
 import GroupMatchList from "@/app/components/standings/group-match-list"
 
@@ -16,8 +15,7 @@ interface StandingsGroupsProps {
 
 /**
  * Standings, one group at a time. A pill selector switches between groups; the
- * chosen group shows its table alongside a globe zoomed to the venues hosting
- * its fixtures, each marked with a pill of the matchup's flags.
+ * chosen group shows its table.
  *
  * The selected group is mirrored into the URL (via replace, so it doesn't grow
  * browser history) so that navigating to a match and back lands on the same
@@ -29,7 +27,6 @@ export default function StandingsGroups({groups, matchesByGroup, initialGroup}: 
     const [active, setActive] = useState(initial)
     const selected = groups.find(g => g.group === active) ?? groups[0]
     const matches = matchesByGroup[selected.group] ?? []
-    const venueCount = new Set(matches.map(m => m.venue)).size
 
     function selectGroup(group: string): void {
         setActive(group)
@@ -59,35 +56,7 @@ export default function StandingsGroups({groups, matchesByGroup, initialGroup}: 
                 })}
             </div>
 
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
-                <div className="relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px] shadow-2xl shadow-cyan-500/10">
-                    <div className="relative rounded-3xl bg-white dark:bg-gray-900/80 backdrop-blur-xl overflow-hidden">
-                        <div className="relative w-full aspect-square sm:aspect-[16/10] bg-gradient-to-br from-slate-100 via-slate-50 to-slate-100 dark:from-gray-900 dark:via-slate-900 dark:to-gray-900">
-                            <div className="absolute inset-0">
-                                {matches.length > 0 ? (
-                                    <GroupVenueMap key={selected.group} matches={matches}/>
-                                ) : (
-                                    <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-slate-500 dark:text-gray-400">
-                                        Venues for Group {selected.group} will appear here once its fixtures are scheduled.
-                                    </div>
-                                )}
-                            </div>
-                            <div className="absolute top-4 left-4 right-4 flex items-center justify-between pointer-events-none">
-                                <span className="inline-flex items-center gap-2 rounded-full bg-white/80 border border-slate-200 text-slate-700 dark:bg-black/50 dark:border-white/10 dark:text-gray-200 px-3 py-1 text-xs font-semibold backdrop-blur">
-                                    Group {selected.group} venues
-                                </span>
-                                {venueCount > 0 && (
-                                    <span className="rounded-full bg-white/80 border border-slate-200 text-slate-600 dark:bg-black/50 dark:border-white/10 dark:text-gray-300 px-3 py-1 text-xs backdrop-blur">
-                                        {venueCount} {venueCount === 1 ? "venue" : "venues"}
-                                    </span>
-                                )}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <GroupTable group={selected.group} standings={selected.standings}/>
-            </div>
+            <GroupTable group={selected.group} standings={selected.standings}/>
 
             <GroupMatchList group={selected.group} matches={matches}/>
         </section>


### PR DESCRIPTION
The group venue globe was rendering incorrectly, so hide it for now and
let the group table take the full width. The GroupVenueMap component is
left in place for an easy re-enable once it's fixed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RBFWHxism78u7o1MAG23RQ