### PR TITLE
feat: return toGoThrough on prediction responses

### DIFF
--- a/contract/api-contract.yaml
+++ b/contract/api-contract.yaml
@@ -49,6 +49,9 @@ components:
         userId:
           description: The user who made the prediction
           type: string
+        toGoThrough:
+          description: For knockout games, the team the user backed to go through
+          $ref: '#/components/schemas/toGoThrough'
     match:
       type: object
       required:

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/MatchResource.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/MatchResource.kt
@@ -31,6 +31,7 @@ import scorcerer.server.services.setScore
 import scorcerer.server.toJson
 import scorcerer.utils.LeaderboardService
 import scorcerer.utils.toTitleCase
+import scorcerer.utils.toToGoThrough
 import scorcerer.utils.toUser
 
 fun matchRoutes(
@@ -57,7 +58,7 @@ fun matchRoutes(
                 (predictions innerJoin LeagueMembershipTable).selectAll().where { (PredictionTable.matchId eq matchId.toInt()).and(LeagueMembershipTable.leagueId eq leagueId) }
             }.map { row ->
                 PredictionWithUser(
-                    Prediction(row[PredictionTable.homeScore], row[PredictionTable.chip], row[PredictionTable.awayScore], row[PredictionTable.matchId].toString(), row[PredictionTable.id].toString(), row[PredictionTable.memberId], row[PredictionTable.points]),
+                    Prediction(row[PredictionTable.homeScore], row[PredictionTable.chip], row[PredictionTable.awayScore], row[PredictionTable.matchId].toString(), row[PredictionTable.id].toString(), row[PredictionTable.memberId], row[PredictionTable.points], row[PredictionTable.result].toToGoThrough()),
                     row.toUser(),
                 )
             }
@@ -151,7 +152,7 @@ private fun listMatches(requesterUserId: String, filterType: String?, userId: St
                 row[homeTeamTable[TeamTable.ranking]], row[awayTeamTable[TeamTable.ranking]],
                 row[MatchTable.homeScore], row[MatchTable.awayScore],
                 row.getOrNull(predictions[PredictionTable.id])?.let {
-                    Prediction(row[predictions[PredictionTable.homeScore]], row[predictions[PredictionTable.chip]], row[predictions[PredictionTable.awayScore]], row[MatchTable.id].toString(), row[predictions[PredictionTable.id]].toString(), row[predictions[PredictionTable.memberId]], row[predictions[PredictionTable.points]])
+                    Prediction(row[predictions[PredictionTable.homeScore]], row[predictions[PredictionTable.chip]], row[predictions[PredictionTable.awayScore]], row[MatchTable.id].toString(), row[predictions[PredictionTable.id]].toString(), row[predictions[PredictionTable.memberId]], row[predictions[PredictionTable.points]], row[predictions[PredictionTable.result]].toToGoThrough())
                 },
                 predictionDistributionFromRow(row),
             )

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/Prediction.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/Prediction.kt
@@ -25,6 +25,7 @@ import scorcerer.server.db.tables.PredictionTable
 import scorcerer.server.extractUserId
 import scorcerer.server.fromJson
 import scorcerer.server.toJson
+import scorcerer.utils.toToGoThrough
 import java.time.OffsetDateTime
 
 private fun chipColumn(chip: Chip) = when (chip) {
@@ -139,6 +140,7 @@ fun predictionRoutes(contexts: RequestContexts) = routes(
                         row[PredictionTable.id].toString(),
                         row[PredictionTable.memberId],
                         row[PredictionTable.points],
+                        row[PredictionTable.result].toToGoThrough(),
                     )
                 } ?: throw ApiResponseError(Response(Status.NOT_FOUND).body("Match does not exist"))
         }

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/User.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/User.kt
@@ -45,6 +45,7 @@ import scorcerer.utils.filterLeaderboardToLeague
 import scorcerer.utils.livePointsForUser
 import scorcerer.utils.toCountryLeagueId
 import scorcerer.utils.toTitleCase
+import scorcerer.utils.toToGoThrough
 import scorcerer.utils.toUser
 
 data class OAuthSignupRequest(val userId: String, val email: String, val firstName: String, val familyName: String)
@@ -261,7 +262,7 @@ fun userRoutes(contexts: RequestContexts, leaderboardService: LeaderboardService
         val userId = req.path("userId")!!
         val predictions = transaction {
             PredictionTable.selectAll().where { PredictionTable.memberId eq userId }.map { row ->
-                Prediction(row[PredictionTable.homeScore], row[PredictionTable.chip], row[PredictionTable.awayScore], row[PredictionTable.matchId].toString(), row[PredictionTable.id].toString(), row[PredictionTable.memberId], row[PredictionTable.points])
+                Prediction(row[PredictionTable.homeScore], row[PredictionTable.chip], row[PredictionTable.awayScore], row[PredictionTable.matchId].toString(), row[PredictionTable.id].toString(), row[PredictionTable.memberId], row[PredictionTable.points], row[PredictionTable.result].toToGoThrough())
             }
         }
         Response(Status.OK).body(predictions.toJson())

--- a/lambdas/src/main/kotlin/scorcerer/utils/PredictionMapper.kt
+++ b/lambdas/src/main/kotlin/scorcerer/utils/PredictionMapper.kt
@@ -1,0 +1,12 @@
+package scorcerer.utils
+
+import org.openapitools.server.models.ToGoThrough
+import scorcerer.server.db.tables.MatchResult
+
+/**
+ * The team a user backed to progress in a knockout match is persisted in
+ * PredictionTable.result; expose it on the API model as [ToGoThrough]. Null for
+ * group-stage predictions, and for any knockout prediction made before a side
+ * was captured.
+ */
+fun MatchResult?.toToGoThrough(): ToGoThrough? = this?.let { ToGoThrough.valueOf(it.name) }


### PR DESCRIPTION
Add toGoThrough to the prediction schema so the knockout side a user backed to progress is exposed on reads (it was only accepted on writes before). Map it from the persisted PredictionTable.result column via a new MatchResult.toToGoThrough() helper, wired into every client-facing Prediction response.