### PR TITLE
Hide stage filter on global, group-stage and knockout leagues

### DIFF
--- a/frontend/app/app/league/[leagueId]/leaderboard/page.tsx
+++ b/frontend/app/app/league/[leagueId]/leaderboard/page.tsx
@@ -10,6 +10,7 @@ import BackButton from "@/app/components/back-button";
 import {getConfigWithAuthHeader} from "@/app/api/client-config";
 import {GetLeagueLeaderboardStageEnum, LeagueApi, LeagueKindEnum} from "@/client";
 import {PitchPerspective} from "@/app/components/atmosphere";
+import {supportsStageFilter} from "@/app/util/leagues";
 
 function parseStage(stageParam: string | string[] | undefined): GetLeagueLeaderboardStageEnum {
     const value = typeof stageParam === "string" ? stageParam : undefined
@@ -21,7 +22,12 @@ export default async function Home(
     { params, searchParams }: { params: Promise<{ leagueId: string }>, searchParams: Promise<{ [key: string]: string | string[] | undefined }> }
 ): Promise<React.JSX.Element> {
     const { leagueId } = await params
-    const stage = parseStage((await searchParams)["stage"])
+    // The global, group-stage and knockout leagues don't offer stage filtering,
+    // so ignore any ?stage= param and always show the full leaderboard there.
+    const stageFilterEnabled = supportsStageFilter(leagueId)
+    const stage = stageFilterEnabled
+        ? parseStage((await searchParams)["stage"])
+        : GetLeagueLeaderboardStageEnum.All
 
     const league = await new LeagueApi(await getConfigWithAuthHeader())
         .getLeague({ leagueId })
@@ -50,7 +56,7 @@ export default async function Home(
                 </header>
 
                 <section className="flex flex-col items-center space-y-5">
-                    <StageTabs leagueId={leagueId} activeStage={stage} />
+                    {stageFilterEnabled && <StageTabs leagueId={leagueId} activeStage={stage} />}
                     <Leaderboard shouldPaginate={true} leagueId={leagueId} limit={false} stage={stage} />
                     {showInvitePrompt && league && (
                         <InvitePrompt leagueId={leagueId} leagueName={league.name}/>

--- a/frontend/app/util/leagues.ts
+++ b/frontend/app/util/leagues.ts
@@ -6,6 +6,16 @@ export function isManagedLeague(kind: LeagueKindEnum): boolean {
     return kind !== LeagueKindEnum.User
 }
 
+// Leagues that don't offer the stage filter (All / Group Stage / Knockout):
+// the global league already shows every stage, and the "group-stage" and
+// "knockout" leagues are themselves stage-scoped, so the tabs would be
+// redundant on those pages.
+const STAGE_FILTER_EXEMPT_LEAGUE_IDS = new Set(["global", "group-stage", "knockout"])
+
+export function supportsStageFilter(leagueId: string): boolean {
+    return !STAGE_FILTER_EXEMPT_LEAGUE_IDS.has(leagueId)
+}
+
 // The canonical invite link for a league. New users can sign up straight from it,
 // and it's the same URL we encode into the scannable QR code.
 export function inviteUrl(leagueId: string): string {


### PR DESCRIPTION
## What

Disables the All / Group Stage / Knockout stage-filter tabs on three standing league leaderboard pages:

- **Global** league
- **Group Stage** league
- **Knockout** league

## Why

The stage filter is redundant (and misleading) on these leagues:

- The **global** league already shows points across every stage, so filtering it would just duplicate the dedicated Group Stage / Knockout leagues.
- The **group-stage** and **knockout** leagues are themselves already scoped to a single stage, so offering stage tabs on them makes no sense.

The filter remains available on all user-created and country leagues, where it's useful.

## How

- Added `supportsStageFilter(leagueId)` to `app/util/leagues.ts`, with the three exempt league IDs (`global`, `group-stage`, `knockout`) kept in one place.
- In the league leaderboard page (`app/app/league/[leagueId]/leaderboard/page.tsx`):
  - `StageTabs` is only rendered when `supportsStageFilter` is true.
  - Any incoming `?stage=` query param is ignored for the exempt leagues — the stage is forced to `ALL` so the full leaderboard always renders, even if a stale URL carries a stage value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdVXpBhpeZoF1wUeWdtbWs)_