### PR TITLE
fix: stage-scope the group-stage and knockout league leaderboards

### DIFF
--- a/lambdas/src/main/kotlin/scorcerer/server/resources/League.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/League.kt
@@ -102,8 +102,18 @@ fun leagueRoutes(contexts: RequestContexts, leaderboardService: LeaderboardServi
         val leagueName = transaction {
             LeagueTable.select(LeagueTable.name).where { LeagueTable.id eq leagueId }.singleOrNull()?.get(LeagueTable.name)
         } ?: throw ApiResponseError(Response(Status.BAD_REQUEST).body("League does not exist"))
-        val response = if (stage != LeaderboardStage.ALL) {
-            paginateLeaderboard(leagueName, calculateStageLeaderboard(leagueId, stage), page, pageSize)
+        // The dedicated "group-stage" and "knockout" leagues are themselves stage-scoped:
+        // every member belongs to them, so filtering the global leaderboard to membership
+        // would just reproduce the full all-stages board. Derive the stage from the league
+        // id so their leaderboards only count points earned in that stage. (These leagues
+        // don't expose the stage tabs, so any ?stage= on them is ignored.)
+        val effectiveStage = when (leagueId) {
+            "group-stage" -> LeaderboardStage.GROUP_STAGE
+            "knockout" -> LeaderboardStage.KNOCKOUT
+            else -> stage
+        }
+        val response = if (effectiveStage != LeaderboardStage.ALL) {
+            paginateLeaderboard(leagueName, calculateStageLeaderboard(leagueId, effectiveStage), page, pageSize)
         } else {
             val (latestMatchDay, latestGlobalLeaderboard) = runBlocking {
                 val matchDay = leaderboardService.getLatestLeaderboardMatchDay()

--- a/lambdas/src/test/kotlin/scorcerer/resources/LeagueTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/resources/LeagueTest.kt
@@ -152,6 +152,42 @@ class LeagueTest : DatabaseTest() {
     }
 
     @Test
+    fun knockoutLeagueOnlyCountsKnockoutPointsWithoutStageParam() {
+        // The dedicated "knockout" league is stage-scoped by its id: even with no
+        // ?stage= param it must show only knockout points, not the full total.
+        givenLeagueExists("knockout", "Knockout")
+        givenUserInLeague("test-user", "knockout")
+        val home = givenTeamExists("Home")
+        val away = givenTeamExists("Away")
+        val groupStageMatch = givenMatchExists(home, away, matchState = Match.State.COMPLETED, round = MatchRound.GROUP_STAGE)
+        val knockoutMatch = givenMatchExists(home, away, matchState = Match.State.COMPLETED, round = MatchRound.SEMI_FINAL)
+        givenPredictionExists(groupStageMatch, "test-user", 1, 0, points = 3)
+        givenPredictionExists(knockoutMatch, "test-user", 1, 0, points = 5)
+
+        val response = handler(Request(Method.GET, "/league/knockout/leaderboard"))
+        response.status shouldBe Status.OK
+        val body: GetLeagueLeaderboard200Response = response.bodyString().fromJson()
+        body.leaderboard.find { it.user.userId == "test-user" }!!.user.livePoints shouldBe 5
+    }
+
+    @Test
+    fun groupStageLeagueOnlyCountsGroupStagePointsWithoutStageParam() {
+        givenLeagueExists("group-stage", "Group Stage")
+        givenUserInLeague("test-user", "group-stage")
+        val home = givenTeamExists("Home")
+        val away = givenTeamExists("Away")
+        val groupStageMatch = givenMatchExists(home, away, matchState = Match.State.COMPLETED, round = MatchRound.GROUP_STAGE)
+        val knockoutMatch = givenMatchExists(home, away, matchState = Match.State.COMPLETED, round = MatchRound.FINAL)
+        givenPredictionExists(groupStageMatch, "test-user", 1, 0, points = 3)
+        givenPredictionExists(knockoutMatch, "test-user", 1, 0, points = 5)
+
+        val response = handler(Request(Method.GET, "/league/group-stage/leaderboard"))
+        response.status shouldBe Status.OK
+        val body: GetLeagueLeaderboard200Response = response.bodyString().fromJson()
+        body.leaderboard.find { it.user.userId == "test-user" }!!.user.livePoints shouldBe 3
+    }
+
+    @Test
     fun leaderboardRejectsInvalidStage() {
         givenLeagueExists("test-league", "Test League")
         val response = handler(Request(Method.GET, "/league/test-league/leaderboard?stage=NOT_A_STAGE"))


### PR DESCRIPTION
## Problem

In prod the **Group Stage** and **Knockout** league pages show the *same* point totals, and neither reflects its stage.

The dedicated `group-stage` and `knockout` leagues (added in V15) contain **every member**. Those league pages are stage-filter-exempt on the frontend, so they request the leaderboard with `stage=ALL`. On that path the backend returns the global leaderboard *filtered to league membership* — but since both leagues contain all members, the filter is a no-op and both render the full all-stages points total.

So the V15 intent ("their leaderboards are filtered to points earned on matches in that stage, see `calculateStageLeaderboard`") was never actually wired up: nothing mapped `leagueId == "knockout"` to `LeaderboardStage.KNOCKOUT`.

## Fix

In the leaderboard handler, derive the effective stage from the league id for these two leagues so they route through `calculateStageLeaderboard`:

```kotlin
val effectiveStage = when (leagueId) {
    "group-stage" -> LeaderboardStage.GROUP_STAGE
    "knockout" -> LeaderboardStage.KNOCKOUT
    else -> stage
}
```

- `group-stage` now counts only group-stage points; `knockout` only knockout-round points.
- User leagues are unchanged and still honour the `?stage=` tabs (`else -> stage`).
- No contract/frontend change needed — the stage tabs stay hidden on these leagues.

## Tests

Added two tests to `LeagueTest` asserting that the `knockout` and `group-stage` leagues count only their stage's points **without** a `?stage=` param. Full `LeagueTest` suite passes (14/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0171P2F8H7gcQfduKDsCzUgN)_