### PR TITLE
Order app leagues and fix stage-league position preview

### DIFF
--- a/frontend/app/components/leaderboard/your-leagues-fetch.tsx
+++ b/frontend/app/components/leaderboard/your-leagues-fetch.tsx
@@ -4,6 +4,7 @@ import {League, UserApi} from "@/client";
 import React, {useEffect, useState} from "react";
 import LeagueComponent from "@/app/components/leaderboard/league";
 import {getConfigWithAuthHeaderClient} from "@/app/api/client-config-client-side";
+import {sortLeagues} from "@/app/util/leagues";
 
 export default function YourLeaguesFetch({initialLeagues}: {initialLeagues: League[]}): React.JSX.Element {
     // Seed from the server-rendered list. Only refetch when the seed is empty (e.g. the
@@ -41,7 +42,7 @@ export default function YourLeaguesFetch({initialLeagues}: {initialLeagues: Leag
 
     return (
         <div className="space-y-2.5">
-            {leagues.map(league => (
+            {sortLeagues(leagues).map(league => (
                 <LeagueComponent
                     key={league.leagueId}
                     leagueId={league.leagueId}

--- a/frontend/app/util/leagues.ts
+++ b/frontend/app/util/leagues.ts
@@ -1,9 +1,27 @@
-import { LeagueKindEnum } from "@/client"
+import { League, LeagueKindEnum } from "@/client"
 
 // Managed leagues are assigned automatically (the global league and the per-country
 // leagues) — members can't manually join or leave them.
 export function isManagedLeague(kind: LeagueKindEnum): boolean {
     return kind !== LeagueKindEnum.User
+}
+
+// The fixed display order for the tournament-wide standing leagues: Global first,
+// then the two stage-scoped boards. Anything not listed here (the user's own
+// leagues, then their country league) is ordered afterwards.
+const STANDING_LEAGUE_ORDER = ["global", "group-stage", "knockout"]
+
+function leagueSortRank(league: League): number {
+    const fixedIndex = STANDING_LEAGUE_ORDER.indexOf(league.leagueId)
+    if (fixedIndex !== -1) return fixedIndex
+    // User-created leagues come next, with the auto-assigned country league last.
+    return league.kind === LeagueKindEnum.User ? STANDING_LEAGUE_ORDER.length : STANDING_LEAGUE_ORDER.length + 1
+}
+
+// Order leagues for display: Global, Group Stage, Knockout, then the user's own
+// leagues (alphabetically), then their country league.
+export function sortLeagues(leagues: League[]): League[] {
+    return [...leagues].sort((a, b) => leagueSortRank(a) - leagueSortRank(b) || a.name.localeCompare(b.name))
 }
 
 // Leagues that don't offer the stage filter (All / Group Stage / Knockout):

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/User.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/User.kt
@@ -40,6 +40,8 @@ import scorcerer.server.fromJson
 import scorcerer.server.log
 import scorcerer.server.toJson
 import scorcerer.utils.LeaderboardService
+import scorcerer.utils.LeaderboardStage
+import scorcerer.utils.calculateStageLeaderboard
 import scorcerer.utils.capitaliseName
 import scorcerer.utils.filterLeaderboardToLeague
 import scorcerer.utils.livePointsForUser
@@ -237,10 +239,20 @@ fun userRoutes(contexts: RequestContexts, leaderboardService: LeaderboardService
         }
 
         val leagues = leaguesByMembership.map { (leagueId, row) ->
-            val yourPosition = if (row.kind == LeagueKind.GLOBAL) {
-                globalLeaderboard?.firstOrNull { it.user.userId == requesterUserId }?.position
-            } else {
-                filterLeaderboardToLeague(globalLeaderboard, row.userIds)
+            // The "group-stage" and "knockout" standing leagues are stored as GLOBAL but
+            // are stage-scoped: their positions must come from the stage leaderboard, not
+            // the all-stages global one (which would otherwise mirror the global position).
+            val stage = when (leagueId) {
+                "group-stage" -> LeaderboardStage.GROUP_STAGE
+                "knockout" -> LeaderboardStage.KNOCKOUT
+                else -> null
+            }
+            val yourPosition = when {
+                stage != null -> calculateStageLeaderboard(leagueId, stage)
+                    .firstOrNull { it.user.userId == requesterUserId }?.position
+                row.kind == LeagueKind.GLOBAL ->
+                    globalLeaderboard?.firstOrNull { it.user.userId == requesterUserId }?.position
+                else -> filterLeaderboardToLeague(globalLeaderboard, row.userIds)
                     .firstOrNull { it.user.userId == requesterUserId }?.position
             }
             League(leagueId, row.name, row.kind.toApiKind(), row.users, yourPosition)

--- a/lambdas/src/test/kotlin/scorcerer/resources/UserTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/resources/UserTest.kt
@@ -12,6 +12,7 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.Test
 import org.openapitools.server.models.GetUserPoints200Response
+import org.openapitools.server.models.League
 import org.openapitools.server.models.Prediction
 import scorcerer.DatabaseTest
 import scorcerer.givenLeagueExists
@@ -22,6 +23,7 @@ import scorcerer.givenUserExists
 import scorcerer.givenUserInLeague
 import scorcerer.server.auth.DatabaseAuthProvider
 import scorcerer.server.db.tables.LeagueMembershipTable
+import scorcerer.server.db.tables.MatchRound
 import scorcerer.server.db.tables.MemberTable
 import scorcerer.server.fromJson
 import scorcerer.server.resources.userRoutes
@@ -79,6 +81,32 @@ class UserTest : DatabaseTest() {
 
         val response = handler(Request(Method.GET, "/user/leagues"))
         response.status shouldBe Status.OK
+    }
+
+    @Test
+    fun getUserLeaguesUsesStageLeaderboardForStandingLeagues() {
+        givenUserExists("test-user", "name0")
+        givenUserExists("user2", "name2")
+        givenLeagueExists("group-stage", "Group Stage")
+        givenUserInLeague("test-user", "group-stage")
+        givenUserInLeague("user2", "group-stage")
+
+        val homeTeamId = givenTeamExists("England")
+        val awayTeamId = givenTeamExists("France")
+        // Only group-stage points should count towards the group-stage league position.
+        val groupMatch = givenMatchExists(homeTeamId, awayTeamId, round = MatchRound.GROUP_STAGE)
+        val knockoutMatch = givenMatchExists(homeTeamId, awayTeamId, round = MatchRound.ROUND_OF_SIXTEEN)
+        // user2 leads the group stage; test-user only pulls ahead once knockout points
+        // are included, so a global-leaderboard position would be wrong here.
+        givenPredictionExists(groupMatch, "test-user", 1, 1, points = 1)
+        givenPredictionExists(groupMatch, "user2", 1, 1, points = 5)
+        givenPredictionExists(knockoutMatch, "test-user", 1, 1, points = 9)
+
+        val response = handler(Request(Method.GET, "/user/leagues"))
+        response.status shouldBe Status.OK
+        val leagues: List<League> = response.bodyString().fromJson()
+        val groupStage = leagues.single { it.leagueId == "group-stage" }
+        groupStage.yourPosition shouldBe 2
     }
 
     @Test


### PR DESCRIPTION
Display the user's leagues in a fixed order on the main app page —
Global, Group Stage, Knockout, then their own leagues (and country
league) — via a shared sortLeagues helper applied where the list is
rendered.

Fix the position preview for the group-stage and knockout standing
leagues. These are stored as GLOBAL-kind leagues, so getUserLeagues was
reading their position from the all-stages global leaderboard, which
mirrors the global position rather than the stage-scoped one. Derive the
position from calculateStageLeaderboard for these leagues instead.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WnxkQGVhZ9ESvchRX2tu34