### PR TITLE
Move stage selector below league name on league pages

### DIFF
--- a/frontend/app/app/league/[leagueId]/leaderboard/page.tsx
+++ b/frontend/app/app/league/[leagueId]/leaderboard/page.tsx
@@ -56,8 +56,13 @@ export default async function Home(
                 </header>
 
                 <section className="flex flex-col items-center space-y-5">
-                    {stageFilterEnabled && <StageTabs leagueId={leagueId} activeStage={stage} />}
-                    <Leaderboard shouldPaginate={true} leagueId={leagueId} limit={false} stage={stage} />
+                    <Leaderboard
+                        shouldPaginate={true}
+                        leagueId={leagueId}
+                        limit={false}
+                        stage={stage}
+                        stageTabs={stageFilterEnabled ? <StageTabs leagueId={leagueId} activeStage={stage} /> : undefined}
+                    />
                     {showInvitePrompt && league && (
                         <InvitePrompt leagueId={leagueId} leagueName={league.name}/>
                     )}

--- a/frontend/app/components/leaderboard/entries.tsx
+++ b/frontend/app/components/leaderboard/entries.tsx
@@ -10,7 +10,8 @@ export interface EntriesProps {
     leagueId: string,
     limit: boolean,
     shouldPaginate: boolean,
-    stage?: GetLeagueLeaderboardStageEnum
+    stage?: GetLeagueLeaderboardStageEnum,
+    stageTabs?: React.ReactNode
 }
 
 function TrophyIcon({className}: {className?: string}): React.JSX.Element {
@@ -88,6 +89,11 @@ export default async function Entries(props: EntriesProps): Promise<React.JSX.El
                         </p>
                     </div>
                 )
+            )}
+            {props.stageTabs && (
+                <div className="mb-6 flex justify-center">
+                    {props.stageTabs}
+                </div>
             )}
             <LeaderboardPagination
                 shouldPaginate={props.shouldPaginate}

--- a/frontend/app/components/leaderboard/leaderboard.tsx
+++ b/frontend/app/components/leaderboard/leaderboard.tsx
@@ -7,14 +7,15 @@ interface LeaderboardProps {
     leagueId: string,
     limit: boolean,
     shouldPaginate: boolean,
-    stage?: GetLeagueLeaderboardStageEnum
+    stage?: GetLeagueLeaderboardStageEnum,
+    stageTabs?: React.ReactNode
 }
 
 export default function Leaderboard(props: LeaderboardProps): React.JSX.Element {
     return (
         <div className="w-full mx-auto flex flex-col items-center">
             <Suspense fallback={<LeaderboardSkeleton />}>
-                <Entries shouldPaginate={props.shouldPaginate} leagueId={props.leagueId} limit={props.limit} stage={props.stage} />
+                <Entries shouldPaginate={props.shouldPaginate} leagueId={props.leagueId} limit={props.limit} stage={props.stage} stageTabs={props.stageTabs} />
             </Suspense>
         </div>
     )


### PR DESCRIPTION
Pass the All/Group Stage/Knockout StageTabs through Leaderboard into
Entries so they render directly beneath the league name header instead
of above the whole leaderboard card.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QzBKfSzp7mLEr598K8JhjB