### PR TITLE
Fix Knockout Cup league tabs and unpopulated points

### DIFF
--- a/frontend/app/app/bracket/page.tsx
+++ b/frontend/app/app/bracket/page.tsx
@@ -11,6 +11,7 @@ import { getConfigWithAuthHeader } from "@/app/api/client-config"
 import { getUserId } from "@/app/auth/jwt-handler"
 import { League, UserApi } from "@/client"
 import { BRAND_TEXT_GRADIENT } from "@/app/util/css-classes"
+import { isGlobalStandingLeague } from "@/app/util/leagues"
 
 export default async function BracketPage({ searchParams }: {
     searchParams: Promise<Record<string, string | string[] | undefined>>
@@ -26,9 +27,14 @@ export default async function BracketPage({ searchParams }: {
         getUserId(),
     ])
 
+    // "Global" is surfaced as its own tab; the user's leagues already include the
+    // auto-joined standing leagues (global, group-stage, knockout), so drop those
+    // to avoid a duplicate Global and the stage-scoped boards the cup doesn't use.
     const cupTabs: Array<{ id: string; name: string }> = [
         { id: "global", name: "Global" },
-        ...userLeagues.map((league) => ({ id: league.leagueId, name: league.name })),
+        ...userLeagues
+            .filter((league) => !isGlobalStandingLeague(league.leagueId))
+            .map((league) => ({ id: league.leagueId, name: league.name })),
     ]
 
     return (

--- a/frontend/app/util/leagues.ts
+++ b/frontend/app/util/leagues.ts
@@ -18,6 +18,14 @@ function leagueSortRank(league: League): number {
     return league.kind === LeagueKindEnum.User ? STANDING_LEAGUE_ORDER.length : STANDING_LEAGUE_ORDER.length + 1
 }
 
+// The tournament-wide standing leagues (Global, Group Stage, Knockout) that every
+// member is auto-joined to. The Knockout Cup surfaces a single "Global" tab of its
+// own, so callers building its league list use this to drop these from the user's
+// leagues — both the duplicate Global and the stage-scoped boards.
+export function isGlobalStandingLeague(leagueId: string): boolean {
+    return STANDING_LEAGUE_ORDER.includes(leagueId)
+}
+
 // Order leagues for display: Global, Group Stage, Knockout, then the user's own
 // leagues (alphabetically), then their country league.
 export function sortLeagues(leagues: League[]): League[] {

--- a/lambdas/src/main/kotlin/scorcerer/server/services/MatchScoring.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/services/MatchScoring.kt
@@ -43,6 +43,10 @@ fun endMatch(
         it[state] = Match.State.COMPLETED
         it[MatchTable.homeScore] = homeScore
         it[MatchTable.awayScore] = awayScore
+        // Record which side went through so the Knockout Cup can score the tie.
+        // A level score (group-stage draw, or a knockout decided on penalties we
+        // can't see) leaves it null; only knockout rounds read this column.
+        it[MatchTable.result] = goThroughFromScore(homeScore, awayScore)
     }
 
     val pointsByMember = scorePredictions(matchId, homeScore, awayScore)
@@ -169,6 +173,16 @@ fun recalculateAllFixedPoints() = transaction {
         }
     }
     log.info("Recalculated fixed points for ${totalPointsByMember.size} members across ${completedMatches.size} matches")
+}
+
+// Who progresses, derived from the final score. Null on a level score: group-stage
+// draws never go through, and a knockout decided on penalties isn't distinguishable
+// from the scoreline alone. Returns the db `MatchResult` (HOME/AWAY), distinct from
+// the `scorcerer.utils.MatchResult` scoring helper used elsewhere in this file.
+private fun goThroughFromScore(homeScore: Int, awayScore: Int): scorcerer.server.db.tables.MatchResult? = when {
+    homeScore > awayScore -> scorcerer.server.db.tables.MatchResult.HOME
+    awayScore > homeScore -> scorcerer.server.db.tables.MatchResult.AWAY
+    else -> null
 }
 
 private fun scorePredictions(matchId: String, homeScore: Int, awayScore: Int): Map<String, Int> {

--- a/lambdas/src/main/resources/db/migration/V17__backfill_match_result.sql
+++ b/lambdas/src/main/resources/db/migration/V17__backfill_match_result.sql
@@ -1,0 +1,19 @@
+-- Backfill the `result` (which side went through) for matches that already
+-- completed before endMatch started writing it. Without this, the Knockout Cup
+-- sees `actual = NULL` for those ties and awards nobody any points.
+--
+-- Derived from the final score: a level score leaves result NULL (group-stage
+-- draws never progress, and a knockout decided on penalties isn't recoverable
+-- from the scoreline alone). Only completed matches with a decisive score and no
+-- result yet are touched.
+
+UPDATE match
+SET result = CASE
+    WHEN home_score > away_score THEN 'HOME'
+    WHEN away_score > home_score THEN 'AWAY'
+END
+WHERE state = 'COMPLETED'
+  AND result IS NULL
+  AND home_score IS NOT NULL
+  AND away_score IS NOT NULL
+  AND home_score <> away_score;

--- a/lambdas/src/test/kotlin/scorcerer/integration/MatchLifecycleTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/integration/MatchLifecycleTest.kt
@@ -212,11 +212,14 @@ class MatchLifecycleTest : PostgresTest() {
                 .first()[MatchTable.state] shouldBe Match.State.LIVE
         }
 
-        // Goes to COMPLETED
+        // Goes to COMPLETED, and the go-through side is recorded from the score
+        // (home win here) so the Knockout Cup can score the tie.
         endMatch(matchId, 1, 0, leaderboardService)
         transaction {
-            MatchTable.selectAll().where { MatchTable.id eq matchId.toInt() }
-                .first()[MatchTable.state] shouldBe Match.State.COMPLETED
+            MatchTable.selectAll().where { MatchTable.id eq matchId.toInt() }.first().let {
+                it[MatchTable.state] shouldBe Match.State.COMPLETED
+                it[MatchTable.result] shouldBe scorcerer.server.db.tables.MatchResult.HOME
+            }
         }
 
         // Can't set score on completed match


### PR DESCRIPTION
- De-duplicate the cup league tabs: the user's leagues already include the
  auto-joined "global" standing league, so "Global" was listed twice. Filter
  the standing leagues out and keep the dedicated Global tab.
- Drop the Group Stage and Knockout boards from the cup tabs — they're
  stage-scoped global leagues that don't belong in the cup league picker.
- Populate match.result (which side went through) when a match completes, so
  the Knockout Cup can score completed knockout ties. endMatch previously only
  wrote the score, leaving result NULL and every tie scoring zero. Backfill
  already-completed matches via migration V17.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XADCggMK1PxTfbvob2a5FT