### PR TITLE
Knockout cup bracket tweaks

### DIFF
--- a/contract/api-contract.yaml
+++ b/contract/api-contract.yaml
@@ -437,6 +437,7 @@ components:
         - state
         - basePoints
         - bonusPoints
+        - predictable
       properties:
         matchId:
           description: Unique matchId
@@ -493,6 +494,13 @@ components:
             the rest of the tree. Null until a round's slots are seeded.
           type: integer
           format: int32
+        predictable:
+          description: >-
+            Whether the requesting user can currently submit a prediction for this
+            match. A match can exist in the bracket (teams known) before its
+            prediction window opens; such matches are surfaced as locked. Mirrors
+            the upcoming-matches window used by the main predictions screen.
+          type: boolean
     bracket:
       description: The requesting user's Knockout Cup run and running score.
       type: object

--- a/frontend/app/components/bracket/bracket-cell.tsx
+++ b/frontend/app/components/bracket/bracket-cell.tsx
@@ -2,12 +2,21 @@ import React from "react"
 import Link from "next/link"
 import { FlagImage } from "@/app/components/predictions/flag-image"
 import { BracketMatch, ToGoThrough } from "@/client"
+import { DerivedTeam } from "@/app/util/bracket-layout"
 
 export interface CellDims {
     /** A fixed pixel width for the tree, or a CSS width (e.g. "100%") for the fluid mobile list. */
     width: number | string
     height: number
     compact: boolean
+}
+
+/**
+ * Predictions for this match aren't open yet: it's in the DB (teams may be known)
+ * but its prediction window hasn't opened. Decided/in-play matches are never locked.
+ */
+export function isMatchLocked(match: BracketMatch): boolean {
+    return match.state === "UPCOMING" && !match.predictable
 }
 
 interface BracketCellProps {
@@ -120,6 +129,53 @@ function TeamLine({ side, name, flag, userPick, actual, correct, points, bonus, 
                 : through
                     ? <span aria-label="went through" className="shrink-0 text-[11px] font-bold text-emerald-600 dark:text-emerald-400">✓</span>
                     : null}
+        </div>
+    )
+}
+
+/**
+ * An as-yet-unplayed slot. Once the matches feeding it have results, the teams
+ * that went through are shown (one line filled while a single feeder is decided,
+ * both once it's a full tie); until then each unknown side reads "TBD".
+ */
+export function PlaceholderCell({ dims, home, away }: {
+    dims: CellDims
+    home?: DerivedTeam
+    away?: DerivedTeam
+}): React.JSX.Element {
+    const flagSize = dims.compact ? 15 : 18
+    const nameClass = dims.compact ? "text-[11px]" : "text-[12px]"
+    return (
+        <div
+            className="flex flex-col overflow-hidden rounded-xl border border-dashed border-slate-900/10 bg-slate-500/[0.04] dark:border-white/10 dark:bg-white/[0.02]"
+            style={{ width: dims.width, height: dims.height }}
+        >
+            <FeederLine team={home} flagSize={flagSize} nameClass={nameClass} />
+            <div className="h-px bg-slate-900/10 dark:bg-white/10" />
+            <FeederLine team={away} flagSize={flagSize} nameClass={nameClass} />
+        </div>
+    )
+}
+
+function FeederLine({ team, flagSize, nameClass }: {
+    team?: DerivedTeam
+    flagSize: number
+    nameClass: string
+}): React.JSX.Element {
+    if (!team) {
+        return (
+            <div className="flex flex-1 items-center justify-center">
+                <span className="text-[10px] font-bold uppercase tracking-widest text-slate-300 dark:text-gray-600">TBD</span>
+            </div>
+        )
+    }
+    return (
+        <div className="flex flex-1 items-center gap-1.5 pr-1.5">
+            <span className="h-full w-0.5 shrink-0 bg-transparent" />
+            <FlagImage code={team.flag} name={team.name} size={flagSize} />
+            <span className={`min-w-0 flex-1 truncate font-medium leading-none text-slate-500 dark:text-gray-400 ${nameClass}`}>
+                {team.name}
+            </span>
         </div>
     )
 }

--- a/frontend/app/components/bracket/bracket-tree.tsx
+++ b/frontend/app/components/bracket/bracket-tree.tsx
@@ -2,8 +2,9 @@
 
 import React, { useEffect, useState } from "react"
 import { BracketMatch } from "@/client"
-import { BracketRound, KNOCKOUT_ROUNDS, ROUND_LABELS, ROUND_SHORT_LABELS } from "@/app/util/bracket-scoring"
-import BracketCell, { CellDims, LockIcon } from "./bracket-cell"
+import { ROUND_LABELS, ROUND_SHORT_LABELS } from "@/app/util/bracket-scoring"
+import { RoundColumn, Slot, buildBracket } from "@/app/util/bracket-layout"
+import BracketCell, { CellDims, LockIcon, PlaceholderCell, isMatchLocked } from "./bracket-cell"
 
 // Desktop tree geometry.
 const CARD_W = 188
@@ -14,25 +15,8 @@ const HEADER_H = 26
 const COL = CARD_W + COL_GAP
 const SLOT = CARD_H + V_GAP
 
-/** Expected match count per round in a standard 32-team knockout. */
-const ROUND_SIZES: Record<BracketRound, number> = {
-    ROUND_OF_THIRTY_TWO: 16,
-    ROUND_OF_SIXTEEN: 8,
-    QUARTER_FINAL: 4,
-    SEMI_FINAL: 2,
-    FINAL: 1,
-}
-
 interface BracketTreeProps {
     matches: BracketMatch[]
-}
-
-/** A real match or a TBD placeholder slot. */
-type Slot = { kind: "match"; match: BracketMatch } | { kind: "placeholder"; id: string }
-
-interface RoundColumn {
-    round: BracketRound
-    slots: Slot[]
 }
 
 function useCompact(): boolean {
@@ -47,74 +31,42 @@ function useCompact(): boolean {
     return compact
 }
 
-function groupRounds(matches: BracketMatch[]): RoundColumn[] {
-    const byRound = new Map<BracketRound, BracketMatch[]>()
-    for (const match of matches) {
-        const round = match.round as BracketRound
-        const bucket = byRound.get(round)
-        if (bucket) bucket.push(match)
-        else byRound.set(round, [match])
-    }
-
-    // Always render the full bracket: every knockout round, each padded to its
-    // expected size with TBD placeholders. This way the entire empty tree is
-    // visible up front, with real matches filling in as rounds are set.
-    return KNOCKOUT_ROUNDS.map((round) => {
-        // Order by bracket position so consecutive pairs (2j, 2j+1) feed the
-        // right next-round slot. Seeded for the Round of 32; matches without a
-        // position fall back to their incoming (kickoff) order via a stable sort.
-        const real = [...(byRound.get(round) ?? [])].sort(
-            (a, b) => (a.bracketPosition ?? Infinity) - (b.bracketPosition ?? Infinity),
-        )
-        const expected = ROUND_SIZES[round]
-        const placeholders: Slot[] = Array.from(
-            { length: Math.max(0, expected - real.length) },
-            (_, i) => ({ kind: "placeholder", id: `${round}-ph-${i}` } as const),
-        )
-        const slots: Slot[] = [
-            ...real.map((m): Slot => ({ kind: "match", match: m })),
-            ...placeholders,
-        ]
-        return { round, slots }
-    })
+/**
+ * A round can't be predicted yet (header padlock) when none of its real matches
+ * are open — i.e. every match is a future placeholder or a locked upcoming tie,
+ * with nothing live, completed, or currently predictable.
+ */
+function isRoundLocked(column: RoundColumn<BracketMatch>): boolean {
+    return !column.slots.some(
+        (s) => s.kind === "match" && (s.match.state !== "UPCOMING" || s.match.predictable),
+    )
 }
 
 /**
  * The user's knockout run. On desktop it's a left-to-right single-elimination
  * tree with connectors; on phones it's a horizontal snap carousel — one round
- * per swipe, each round a compact scrollable list so it stays short vertically.
- * Rounds beyond the one currently being played are locked (greyed + padlock).
+ * per swipe — capped to a scrollable viewport so it stays short, with the round
+ * heading pinned to the top while you scroll. Matches that are in the bracket but
+ * not yet open for predictions are greyed out and padlocked.
  */
 export default function BracketTree({ matches }: BracketTreeProps): React.JSX.Element {
     const compact = useCompact()
-    const rounds = groupRounds(matches)
-
-    // The earliest round still being played is "open"; later rounds are locked.
-    const openRoundIndex = rounds.findIndex((column) =>
-        column.slots.some((s) => s.kind === "match" && s.match.state !== "COMPLETED")
-    )
-    const isLocked = (r: number): boolean => openRoundIndex !== -1 && r > openRoundIndex
+    const rounds = buildBracket(matches)
 
     return compact
-        ? <MobileCarousel rounds={rounds} isLocked={isLocked} />
-        : <DesktopTree rounds={rounds} isLocked={isLocked} />
+        ? <MobileCarousel rounds={rounds} />
+        : <DesktopTree rounds={rounds} />
 }
 
-/** A greyed-out TBD placeholder cell. */
-function PlaceholderCell({ dims }: { dims: CellDims }): React.JSX.Element {
-    return (
-        <div
-            className="flex items-center justify-center rounded-xl border border-dashed border-slate-900/10 bg-slate-500/[0.04] dark:border-white/10 dark:bg-white/[0.02]"
-            style={{ width: dims.width, height: dims.height }}
-        >
-            <span className="text-[11px] font-bold uppercase tracking-widest text-slate-300 dark:text-gray-600">TBD</span>
-        </div>
-    )
+function renderSlot(slot: Slot<BracketMatch>, dims: CellDims): React.JSX.Element {
+    if (slot.kind === "placeholder") {
+        return <PlaceholderCell dims={dims} home={slot.home} away={slot.away} />
+    }
+    return <BracketCell match={slot.match} locked={isMatchLocked(slot.match)} dims={dims} />
 }
 
-function renderSlot(slot: Slot, locked: boolean, dims: CellDims): React.JSX.Element {
-    if (slot.kind === "placeholder") return <PlaceholderCell dims={dims} />
-    return <BracketCell match={slot.match} locked={locked} dims={dims} />
+function slotKey(slot: Slot<BracketMatch>): string {
+    return slot.kind === "match" ? slot.match.matchId : slot.id
 }
 
 // Mobile bracket geometry
@@ -133,7 +85,7 @@ function mobileCenters(matchCount: number, totalSlots: number): number[] {
 }
 
 /** Phone layout: snap-scroll carousel with proper bracket connector lines. */
-function MobileCarousel({ rounds, isLocked }: { rounds: RoundColumn[]; isLocked: (r: number) => boolean }): React.JSX.Element {
+function MobileCarousel({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): React.JSX.Element {
     const firstRoundCount = rounds[0].slots.length
     const totalH = firstRoundCount * M_SLOT - M_V_GAP
 
@@ -143,11 +95,14 @@ function MobileCarousel({ rounds, isLocked }: { rounds: RoundColumn[]; isLocked:
 
     return (
         <div
-            className="-mx-4 flex snap-x snap-mandatory overflow-x-auto overflow-y-hidden px-4"
-            style={{ WebkitOverflowScrolling: "touch", gap: 0 }}
+            // Scrolls both ways: swipe between rounds, scroll down within a round.
+            // Capped to a fraction of the viewport so the tall first round shrinks
+            // into a contained, scrollable area instead of dominating the page.
+            className="-mx-4 flex snap-x snap-mandatory overflow-auto overscroll-contain px-4"
+            style={{ WebkitOverflowScrolling: "touch", gap: 0, maxHeight: `min(${totalH + M_HEADER_H}px, 70svh)` }}
         >
             {rounds.map((column, r) => {
-                const locked = isLocked(r)
+                const locked = isRoundLocked(column)
                 const centers = centersByRound[r]
                 const prevCenters = r > 0 ? centersByRound[r - 1] : null
                 const dims: CellDims = { width: "100%", height: M_CARD_H, compact: true }
@@ -165,7 +120,7 @@ function MobileCarousel({ rounds, isLocked }: { rounds: RoundColumn[]; isLocked:
                                         return (
                                             <path
                                                 key={j}
-                                                d={`M 0 ${f1} H ${M_CONNECTOR_W / 2} V ${f2} M ${M_CONNECTOR_W / 2} ${midY} H ${M_CONNECTOR_W}`}
+                                                d={`M 0 ${f1} H ${M_CONNECTOR_W / 2} V ${f2} H 0 M ${M_CONNECTOR_W / 2} ${midY} H ${M_CONNECTOR_W}`}
                                                 className="stroke-slate-300 dark:stroke-white/20"
                                                 strokeWidth={1.5}
                                             />
@@ -176,7 +131,10 @@ function MobileCarousel({ rounds, isLocked }: { rounds: RoundColumn[]; isLocked:
                         )}
 
                         <section className="flex shrink-0 snap-center flex-col" style={{ width: "72vw", maxWidth: 300 }}>
-                            <header className="flex shrink-0 items-center justify-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400" style={{ height: M_HEADER_H }}>
+                            <header
+                                className="sticky top-0 z-10 flex shrink-0 items-center justify-center gap-1.5 bg-slate-50/95 text-[11px] font-bold uppercase tracking-[0.2em] text-slate-500 backdrop-blur dark:bg-gray-900/95 dark:text-gray-400"
+                                style={{ height: M_HEADER_H }}
+                            >
                                 {ROUND_LABELS[column.round]}
                                 {locked && <LockIcon className="h-3 w-3 text-slate-400 dark:text-gray-500" />}
                             </header>
@@ -184,11 +142,11 @@ function MobileCarousel({ rounds, isLocked }: { rounds: RoundColumn[]; isLocked:
                             <div className="relative" style={{ height: totalH }}>
                                 {column.slots.map((slot, j) => (
                                     <div
-                                        key={slot.kind === "match" ? slot.match.matchId : slot.id}
+                                        key={slotKey(slot)}
                                         className="absolute w-full"
                                         style={{ top: centers[j] - M_CARD_H / 2 }}
                                     >
-                                        {renderSlot(slot, locked, dims)}
+                                        {renderSlot(slot, dims)}
                                     </div>
                                 ))}
                             </div>
@@ -202,7 +160,7 @@ function MobileCarousel({ rounds, isLocked }: { rounds: RoundColumn[]; isLocked:
 }
 
 /** Desktop layout: the connected bracket tree. */
-function DesktopTree({ rounds, isLocked }: { rounds: RoundColumn[]; isLocked: (r: number) => boolean }): React.JSX.Element {
+function DesktopTree({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): React.JSX.Element {
     const dims: CellDims = { width: CARD_W, height: CARD_H, compact: false }
     const totalHeight = rounds[0].slots.length * SLOT
 
@@ -245,10 +203,11 @@ function DesktopTree({ rounds, isLocked }: { rounds: RoundColumn[]; isLocked: (r
                     {rounds.map((column, r) => (
                         <div
                             key={column.round}
-                            className="absolute text-center text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500 dark:text-gray-400"
+                            className="absolute flex items-center justify-center gap-1 text-center text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500 dark:text-gray-400"
                             style={{ left: r * COL, width: CARD_W }}
                         >
                             {ROUND_SHORT_LABELS[column.round]}
+                            {isRoundLocked(column) && <LockIcon className="h-3 w-3 text-slate-400 dark:text-gray-500" />}
                         </div>
                     ))}
                 </div>
@@ -262,11 +221,11 @@ function DesktopTree({ rounds, isLocked }: { rounds: RoundColumn[]; isLocked: (r
                     {rounds.map((column, r) =>
                         column.slots.map((slot, j) => (
                             <div
-                                key={slot.kind === "match" ? slot.match.matchId : slot.id}
+                                key={slotKey(slot)}
                                 className="absolute"
                                 style={{ left: r * COL, top: centers[r][j] - CARD_H / 2, width: CARD_W }}
                             >
-                                {renderSlot(slot, isLocked(r), dims)}
+                                {renderSlot(slot, dims)}
                             </div>
                         )),
                     )}

--- a/frontend/app/util/__tests__/bracket-layout.test.ts
+++ b/frontend/app/util/__tests__/bracket-layout.test.ts
@@ -1,0 +1,75 @@
+import { LayoutMatch, ROUND_SIZES, Slot, buildBracket } from "@/app/util/bracket-layout"
+
+const r32 = "ROUND_OF_THIRTY_TWO" as const
+const r16 = "ROUND_OF_SIXTEEN" as const
+
+function r32Match(position: number, overrides: Partial<LayoutMatch> = {}): LayoutMatch {
+    return {
+        round: r32,
+        state: "UPCOMING",
+        homeTeam: `Home ${position}`,
+        homeTeamFlagCode: `h${position}`,
+        awayTeam: `Away ${position}`,
+        awayTeamFlagCode: `a${position}`,
+        bracketPosition: position,
+        ...overrides,
+    }
+}
+
+function placeholders(slots: Slot<LayoutMatch>[]): Array<{ home?: string; away?: string }> {
+    return slots
+        .filter((s): s is Extract<Slot<LayoutMatch>, { kind: "placeholder" }> => s.kind === "placeholder")
+        .map((s) => ({ home: s.home?.name, away: s.away?.name }))
+}
+
+describe("buildBracket", () => {
+    it("renders the full tree padded to each round's expected size", () => {
+        const rounds = buildBracket([r32Match(1)])
+        expect(rounds.map((c) => c.round)).toEqual([
+            "ROUND_OF_THIRTY_TWO",
+            "ROUND_OF_SIXTEEN",
+            "QUARTER_FINAL",
+            "SEMI_FINAL",
+            "FINAL",
+        ])
+        rounds.forEach((column) => {
+            expect(column.slots.length).toBe(ROUND_SIZES[column.round])
+        })
+        // The single real match keeps its slot; the rest of R32 is placeholders.
+        expect(rounds[0].slots[0]).toEqual({ kind: "match", match: expect.objectContaining({ bracketPosition: 1 }) })
+        expect(rounds[0].slots[1]).toMatchObject({ kind: "placeholder" })
+    })
+
+    it("orders a round by bracket position regardless of input order", () => {
+        const rounds = buildBracket([r32Match(3), r32Match(1), r32Match(2)])
+        const positions = rounds[0].slots
+            .filter((s): s is Extract<Slot<LayoutMatch>, { kind: "match" }> => s.kind === "match")
+            .map((s) => s.match.bracketPosition)
+        expect(positions).toEqual([1, 2, 3])
+    })
+
+    it("partially fills the fed slot when one feeder is decided", () => {
+        // Slots 1 & 2 of R32 feed slot 0 of R16. Only slot 1 (home) is decided.
+        const rounds = buildBracket([
+            r32Match(1, { state: "COMPLETED", actualGoThrough: "HOME" }),
+            r32Match(2),
+        ])
+        const r16Slots = placeholders(rounds.find((c) => c.round === r16)!.slots)
+        expect(r16Slots[0]).toEqual({ home: "Home 1", away: undefined })
+    })
+
+    it("fully fills the fed slot when both feeders are decided", () => {
+        const rounds = buildBracket([
+            r32Match(1, { state: "COMPLETED", actualGoThrough: "AWAY" }),
+            r32Match(2, { state: "COMPLETED", actualGoThrough: "HOME" }),
+        ])
+        const r16Slots = placeholders(rounds.find((c) => c.round === r16)!.slots)
+        expect(r16Slots[0]).toEqual({ home: "Away 1", away: "Home 2" })
+    })
+
+    it("leaves a slot empty until at least one feeder completes", () => {
+        const rounds = buildBracket([r32Match(1), r32Match(2)])
+        const r16Slots = placeholders(rounds.find((c) => c.round === r16)!.slots)
+        expect(r16Slots[0]).toEqual({ home: undefined, away: undefined })
+    })
+})

--- a/frontend/app/util/bracket-layout.ts
+++ b/frontend/app/util/bracket-layout.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure geometry/derivation for the Knockout Cup bracket tree.
+ *
+ * Groups a user's knockout matches into the full single-elimination tree (every
+ * round padded to its expected size with TBD placeholders) and, where a match's
+ * feeder results are already known, fills the next round's empty slots with the
+ * teams that went through. Kept free of React and the generated client so it can
+ * be unit-tested in isolation (see `__tests__/bracket-layout.test.ts`).
+ */
+
+import { BracketRound, GoThrough, KNOCKOUT_ROUNDS } from "./bracket-scoring"
+
+/** Expected match count per round in a standard 32-team knockout. */
+export const ROUND_SIZES: Record<BracketRound, number> = {
+    ROUND_OF_THIRTY_TWO: 16,
+    ROUND_OF_SIXTEEN: 8,
+    QUARTER_FINAL: 4,
+    SEMI_FINAL: 2,
+    FINAL: 1,
+}
+
+/** The minimum shape `buildBracket` needs from a match to lay out and resolve it. */
+export interface LayoutMatch {
+    round: BracketRound
+    state: "LIVE" | "UPCOMING" | "COMPLETED"
+    homeTeam: string
+    homeTeamFlagCode: string
+    awayTeam: string
+    awayTeamFlagCode: string
+    actualGoThrough?: GoThrough
+    bracketPosition?: number | null
+}
+
+/** A team derived into an as-yet-unplayed slot from a completed feeder. */
+export interface DerivedTeam {
+    name: string
+    flag: string
+}
+
+/**
+ * A real match, or a TBD placeholder that may have one/both feeder winners filled
+ * in once the matches feeding it have completed.
+ */
+export type Slot<M> =
+    | { kind: "match"; match: M }
+    | { kind: "placeholder"; id: string; home?: DerivedTeam; away?: DerivedTeam }
+
+export interface RoundColumn<M> {
+    round: BracketRound
+    slots: Slot<M>[]
+}
+
+/** The side that went through a completed match, or undefined while undecided. */
+function winnerOf(match: LayoutMatch): DerivedTeam | undefined {
+    if (match.state !== "COMPLETED" || match.actualGoThrough == null) return undefined
+    return match.actualGoThrough === "HOME"
+        ? { name: match.homeTeam, flag: match.homeTeamFlagCode }
+        : { name: match.awayTeam, flag: match.awayTeamFlagCode }
+}
+
+/**
+ * Build the full bracket: every knockout round, ordered by bracket position and
+ * padded to its expected size with placeholders. Consecutive pairs (2j, 2j+1)
+ * feed slot j of the next round, so any completed feeder's winner is carried
+ * forward into the (otherwise empty) slot it feeds — partially filling a slot
+ * when one feeder is decided, fully when both are.
+ */
+export function buildBracket<M extends LayoutMatch>(matches: M[]): RoundColumn<M>[] {
+    const byRound = new Map<BracketRound, M[]>()
+    for (const match of matches) {
+        const bucket = byRound.get(match.round)
+        if (bucket) bucket.push(match)
+        else byRound.set(match.round, [match])
+    }
+
+    const columns: RoundColumn<M>[] = KNOCKOUT_ROUNDS.map((round) => {
+        // Order by bracket position so consecutive pairs feed the right next-round
+        // slot; matches without a position keep their incoming (kickoff) order.
+        const real = [...(byRound.get(round) ?? [])].sort(
+            (a, b) => (a.bracketPosition ?? Infinity) - (b.bracketPosition ?? Infinity),
+        )
+        const slots: Slot<M>[] = real.map((match): Slot<M> => ({ kind: "match", match }))
+        for (let i = slots.length; i < ROUND_SIZES[round]; i++) {
+            slots.push({ kind: "placeholder", id: `${round}-ph-${i}` })
+        }
+        return { round, slots }
+    })
+
+    // Carry feeder winners forward, round by round, into the slots they feed.
+    let prevWinners: (DerivedTeam | undefined)[] | null = null
+    for (const column of columns) {
+        const winners = column.slots.map((slot, j): DerivedTeam | undefined => {
+            if (slot.kind === "match") return winnerOf(slot.match)
+            if (prevWinners) {
+                slot.home = prevWinners[2 * j]
+                slot.away = prevWinners[2 * j + 1]
+            }
+            // A placeholder is an unplayed match: it never has a winner to forward.
+            return undefined
+        })
+        prevWinners = winners
+    }
+
+    return columns
+}

--- a/lambdas/src/main/kotlin/scorcerer/server/resources/Bracket.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/resources/Bracket.kt
@@ -58,6 +58,7 @@ fun bracketRoutes(contexts: RequestContexts) = routes(
                 actualGoThrough = row.actual.toToGoThrough(),
                 correct = score.correct,
                 bracketPosition = row.bracketPosition,
+                predictable = row.predictable,
             )
         }
         Response(Status.OK).body(Bracket(matches, run.totalPoints, run.currentStreak).toJson())
@@ -88,6 +89,7 @@ private data class RunRow(
     val pick: MatchResult?,
     val actual: MatchResult?,
     val bracketPosition: Int?,
+    val predictable: Boolean,
 )
 
 private data class ScoredMember(
@@ -101,6 +103,22 @@ private fun loadUserRun(userId: String): List<RunRow> = transaction {
     val awayTeamTable = TeamTable.alias("awayTeam")
     val homeTeamTable = TeamTable.alias("homeTeam")
     val predictions = PredictionTable.selectAll().where { PredictionTable.memberId eq userId }.alias("predictions")
+
+    // A knockout match can sit in the DB (teams known) before its prediction
+    // window opens. Mirror the main predictions screen: only upcoming matches in
+    // the next three match days are predictable; everything else is locked. When
+    // fewer than three upcoming match days exist, they're all open.
+    val upcomingMatchDays = MatchTable
+        .select(MatchTable.matchDay)
+        .where { MatchTable.state eq Match.State.UPCOMING }
+        .map { it[MatchTable.matchDay] }
+        .distinct()
+    val predictableMatchDays = if (upcomingMatchDays.size < 3) {
+        upcomingMatchDays.toSet()
+    } else {
+        upcomingMatchDays.sorted().take(3).toSet()
+    }
+
     MatchTable
         .join(awayTeamTable, JoinType.INNER, MatchTable.awayTeamId, awayTeamTable[TeamTable.id])
         .join(homeTeamTable, JoinType.INNER, MatchTable.homeTeamId, homeTeamTable[TeamTable.id])
@@ -122,6 +140,8 @@ private fun loadUserRun(userId: String): List<RunRow> = transaction {
                 pick = row.getOrNull(predictions[PredictionTable.id])?.let { row[predictions[PredictionTable.result]] },
                 actual = if (completed) row[MatchTable.result] else null,
                 bracketPosition = row[MatchTable.bracketPosition],
+                predictable = row[MatchTable.state] == Match.State.UPCOMING &&
+                    row[MatchTable.matchDay] in predictableMatchDays,
             )
         }
 }


### PR DESCRIPTION
- Fix the missing bottom-feeder connector line on the mobile bracket: the
  lower feeder of each pair now draws its horizontal segment into the
  connector, not just the upper one.
- Lock matches that are in the bracket but not yet open for predictions.
  The bracket endpoint now returns a `predictable` flag (matches the
  upcoming-matches window used by the main predictions screen) and the UI
  greys out / padlocks individual cells and round headings accordingly,
  instead of inferring lockedness purely by round.
- Fill placeholder slots from known feeder results: once a feeder match
  completes, the team that went through is carried into the slot it feeds —
  partially when one feeder is decided, fully when both are.
- Shrink the mobile bracket vertically: the carousel is capped to a
  scrollable viewport instead of dominating the page.
- Keep round headings visible on mobile by pinning them to the top of the
  bracket while scrolling.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LFkNkrvMt2EG9mV4soD7VR