### PR TITLE
Axis-lock the mobile knockout bracket scroll

### DIFF
--- a/frontend/app/components/bracket/bracket-tree.tsx
+++ b/frontend/app/components/bracket/bracket-tree.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { BracketMatch } from "@/client"
 import { ROUND_LABELS, ROUND_SHORT_LABELS } from "@/app/util/bracket-scoring"
 import { RoundColumn, Slot, buildBracket } from "@/app/util/bracket-layout"
@@ -45,11 +45,12 @@ function isRoundLocked(column: RoundColumn<BracketMatch>): boolean {
 /**
  * The user's knockout run. On desktop it's a left-to-right single-elimination
  * tree with connectors; on phones it's a horizontal snap carousel — one round
- * per swipe — capped to a scrollable viewport so it stays short. Touch is axis
- * locked: you swipe left/right to move between rounds and scroll up/down freely
- * within the tree, but it can't be dragged diagonally in every direction. Matches
- * that are in the bracket but not yet open for predictions are greyed out and
- * padlocked.
+ * per swipe — capped to a scrollable viewport so it stays short, with the round
+ * headings pinned above the tree so they stay visible while you scroll. Touch is
+ * axis locked: you swipe left/right to move between rounds and scroll up/down
+ * freely within the tree, but it can't be dragged diagonally in every direction.
+ * Matches that are in the bracket but not yet open for predictions are greyed out
+ * and padlocked.
  */
 export default function BracketTree({ matches }: BracketTreeProps): React.JSX.Element {
     const compact = useCompact()
@@ -90,85 +91,112 @@ function mobileCenters(matchCount: number, totalSlots: number): number[] {
 function MobileCarousel({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): React.JSX.Element {
     const firstRoundCount = rounds[0].slots.length
     const totalH = firstRoundCount * M_SLOT - M_V_GAP
-    const innerH = totalH + M_HEADER_H
 
     const centersByRound: number[][] = rounds.map((col) =>
         mobileCenters(col.slots.length, firstRoundCount)
     )
 
+    // The round headings live in a strip pinned above the scrolling tree, so they
+    // never scroll out of view vertically. The strip mirrors the body's horizontal
+    // scroll position (it isn't directly scrollable) so each heading stays directly
+    // above its round as you swipe between rounds.
+    const headerRef = useRef<HTMLDivElement>(null)
+    const bodyRef = useRef<HTMLDivElement>(null)
+    const syncHeader = (): void => {
+        if (headerRef.current && bodyRef.current) {
+            headerRef.current.scrollLeft = bodyRef.current.scrollLeft
+        }
+    }
+
+    const colWidth = { width: "72vw", maxWidth: 300 } as const
+
     // Two nested scrollers with complementary touch-action lock each gesture to a
     // single axis, so the bracket can't be dragged diagonally in all directions.
-    // The outer scroller owns vertical scrolling (pan-y): a downward swipe scrolls
-    // the whole tree, connectors and all, staying aligned. The inner scroller owns
-    // horizontal swiping (pan-x) and snaps one round per swipe. A vertical gesture
-    // isn't permitted on the inner, so the browser routes it up to the outer; a
-    // horizontal gesture isn't permitted on the outer, so it snaps rounds instead.
-    // Capped to a fraction of the viewport so the tall first round shrinks into a
-    // contained, scrollable area instead of dominating the page.
+    // The outer body scroller owns vertical scrolling (pan-y), the inner one owns
+    // horizontal round-to-round swiping (pan-x) and snaps one round per swipe. A
+    // vertical gesture isn't permitted on the inner, so the browser routes it up to
+    // the outer; a horizontal gesture isn't permitted on the outer, so it snaps.
+    // The body is capped to a fraction of the viewport so the tall first round
+    // shrinks into a contained, scrollable area instead of dominating the page.
     return (
-        <div
-            className="-mx-4 overflow-y-auto overflow-x-hidden overscroll-contain px-4"
-            style={{ WebkitOverflowScrolling: "touch", touchAction: "pan-y", maxHeight: `min(${innerH}px, 70svh)` }}
-        >
-        <div
-            className="flex snap-x snap-mandatory overflow-x-auto overflow-y-hidden overscroll-x-contain"
-            style={{ WebkitOverflowScrolling: "touch", touchAction: "pan-x", gap: 0, height: innerH }}
-        >
-            {rounds.map((column, r) => {
-                const locked = isRoundLocked(column)
-                const centers = centersByRound[r]
-                const prevCenters = r > 0 ? centersByRound[r - 1] : null
-                const dims: CellDims = { width: "100%", height: M_CARD_H, compact: true }
-
-                return (
+        <div className="-mx-4">
+            <div
+                ref={headerRef}
+                className="flex overflow-x-hidden"
+                style={{ touchAction: "none", gap: 0 }}
+            >
+                <div className="shrink-0" style={{ width: 16 }} />
+                {rounds.map((column, r) => (
                     <React.Fragment key={column.round}>
-                        {prevCenters && (
-                            <div className="shrink-0 self-start" style={{ width: M_CONNECTOR_W, paddingTop: M_HEADER_H }}>
-                                <svg width={M_CONNECTOR_W} height={totalH} fill="none" aria-hidden className="pointer-events-none">
-                                    {centers.map((cy, j) => {
-                                        const f1 = prevCenters[2 * j]
-                                        const f2 = prevCenters[2 * j + 1]
-                                        if (f1 == null || f2 == null) return null
-                                        const midY = (f1 + f2) / 2
-                                        return (
-                                            <path
-                                                key={j}
-                                                d={`M 0 ${f1} H ${M_CONNECTOR_W / 2} V ${f2} H 0 M ${M_CONNECTOR_W / 2} ${midY} H ${M_CONNECTOR_W}`}
-                                                className="stroke-slate-300 dark:stroke-white/20"
-                                                strokeWidth={1.5}
-                                            />
-                                        )
-                                    })}
-                                </svg>
-                            </div>
-                        )}
-
-                        <section className="flex shrink-0 snap-center flex-col" style={{ width: "72vw", maxWidth: 300 }}>
-                            <header
-                                className="sticky top-0 z-10 flex shrink-0 items-center justify-center gap-1.5 bg-slate-50/95 text-[11px] font-bold uppercase tracking-[0.2em] text-slate-500 backdrop-blur dark:bg-gray-900/95 dark:text-gray-400"
-                                style={{ height: M_HEADER_H }}
-                            >
-                                {ROUND_LABELS[column.round]}
-                                {locked && <LockIcon className="h-3 w-3 text-slate-400 dark:text-gray-500" />}
-                            </header>
-
-                            <div className="relative" style={{ height: totalH }}>
-                                {column.slots.map((slot, j) => (
-                                    <div
-                                        key={slotKey(slot)}
-                                        className="absolute w-full"
-                                        style={{ top: centers[j] - M_CARD_H / 2 }}
-                                    >
-                                        {renderSlot(slot, dims)}
-                                    </div>
-                                ))}
-                            </div>
-                        </section>
+                        {r > 0 && <div className="shrink-0" style={{ width: M_CONNECTOR_W }} />}
+                        <div
+                            className="flex shrink-0 items-center justify-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-gray-400"
+                            style={{ ...colWidth, height: M_HEADER_H }}
+                        >
+                            {ROUND_LABELS[column.round]}
+                            {isRoundLocked(column) && <LockIcon className="h-3 w-3 text-slate-400 dark:text-gray-500" />}
+                        </div>
                     </React.Fragment>
-                )
-            })}
-            <div className="shrink-0" style={{ width: 16 }} />
-        </div>
+                ))}
+                <div className="shrink-0" style={{ width: 16 }} />
+            </div>
+
+            <div
+                className="overflow-y-auto overflow-x-hidden overscroll-contain"
+                style={{ WebkitOverflowScrolling: "touch", touchAction: "pan-y", maxHeight: `min(${totalH}px, calc(70svh - ${M_HEADER_H}px))` }}
+            >
+                <div
+                    ref={bodyRef}
+                    onScroll={syncHeader}
+                    className="flex snap-x snap-mandatory overflow-x-auto overflow-y-hidden overscroll-x-contain"
+                    style={{ WebkitOverflowScrolling: "touch", touchAction: "pan-x", gap: 0, height: totalH }}
+                >
+                    <div className="shrink-0" style={{ width: 16 }} />
+                    {rounds.map((column, r) => {
+                        const centers = centersByRound[r]
+                        const prevCenters = r > 0 ? centersByRound[r - 1] : null
+                        const dims: CellDims = { width: "100%", height: M_CARD_H, compact: true }
+
+                        return (
+                            <React.Fragment key={column.round}>
+                                {prevCenters && (
+                                    <div className="shrink-0 self-start" style={{ width: M_CONNECTOR_W }}>
+                                        <svg width={M_CONNECTOR_W} height={totalH} fill="none" aria-hidden className="pointer-events-none">
+                                            {centers.map((cy, j) => {
+                                                const f1 = prevCenters[2 * j]
+                                                const f2 = prevCenters[2 * j + 1]
+                                                if (f1 == null || f2 == null) return null
+                                                const midY = (f1 + f2) / 2
+                                                return (
+                                                    <path
+                                                        key={j}
+                                                        d={`M 0 ${f1} H ${M_CONNECTOR_W / 2} V ${f2} H 0 M ${M_CONNECTOR_W / 2} ${midY} H ${M_CONNECTOR_W}`}
+                                                        className="stroke-slate-300 dark:stroke-white/20"
+                                                        strokeWidth={1.5}
+                                                    />
+                                                )
+                                            })}
+                                        </svg>
+                                    </div>
+                                )}
+
+                                <section className="relative shrink-0 snap-center" style={{ ...colWidth, height: totalH }}>
+                                    {column.slots.map((slot, j) => (
+                                        <div
+                                            key={slotKey(slot)}
+                                            className="absolute w-full"
+                                            style={{ top: centers[j] - M_CARD_H / 2 }}
+                                        >
+                                            {renderSlot(slot, dims)}
+                                        </div>
+                                    ))}
+                                </section>
+                            </React.Fragment>
+                        )
+                    })}
+                    <div className="shrink-0" style={{ width: 16 }} />
+                </div>
+            </div>
         </div>
     )
 }

--- a/frontend/app/components/bracket/bracket-tree.tsx
+++ b/frontend/app/components/bracket/bracket-tree.tsx
@@ -45,9 +45,11 @@ function isRoundLocked(column: RoundColumn<BracketMatch>): boolean {
 /**
  * The user's knockout run. On desktop it's a left-to-right single-elimination
  * tree with connectors; on phones it's a horizontal snap carousel — one round
- * per swipe — capped to a scrollable viewport so it stays short, with the round
- * heading pinned to the top while you scroll. Matches that are in the bracket but
- * not yet open for predictions are greyed out and padlocked.
+ * per swipe — capped to a scrollable viewport so it stays short. Touch is axis
+ * locked: you swipe left/right to move between rounds and scroll up/down freely
+ * within the tree, but it can't be dragged diagonally in every direction. Matches
+ * that are in the bracket but not yet open for predictions are greyed out and
+ * padlocked.
  */
 export default function BracketTree({ matches }: BracketTreeProps): React.JSX.Element {
     const compact = useCompact()
@@ -88,18 +90,29 @@ function mobileCenters(matchCount: number, totalSlots: number): number[] {
 function MobileCarousel({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): React.JSX.Element {
     const firstRoundCount = rounds[0].slots.length
     const totalH = firstRoundCount * M_SLOT - M_V_GAP
+    const innerH = totalH + M_HEADER_H
 
     const centersByRound: number[][] = rounds.map((col) =>
         mobileCenters(col.slots.length, firstRoundCount)
     )
 
+    // Two nested scrollers with complementary touch-action lock each gesture to a
+    // single axis, so the bracket can't be dragged diagonally in all directions.
+    // The outer scroller owns vertical scrolling (pan-y): a downward swipe scrolls
+    // the whole tree, connectors and all, staying aligned. The inner scroller owns
+    // horizontal swiping (pan-x) and snaps one round per swipe. A vertical gesture
+    // isn't permitted on the inner, so the browser routes it up to the outer; a
+    // horizontal gesture isn't permitted on the outer, so it snaps rounds instead.
+    // Capped to a fraction of the viewport so the tall first round shrinks into a
+    // contained, scrollable area instead of dominating the page.
     return (
         <div
-            // Scrolls both ways: swipe between rounds, scroll down within a round.
-            // Capped to a fraction of the viewport so the tall first round shrinks
-            // into a contained, scrollable area instead of dominating the page.
-            className="-mx-4 flex snap-x snap-mandatory overflow-auto overscroll-contain px-4"
-            style={{ WebkitOverflowScrolling: "touch", gap: 0, maxHeight: `min(${totalH + M_HEADER_H}px, 70svh)` }}
+            className="-mx-4 overflow-y-auto overflow-x-hidden overscroll-contain px-4"
+            style={{ WebkitOverflowScrolling: "touch", touchAction: "pan-y", maxHeight: `min(${innerH}px, 70svh)` }}
+        >
+        <div
+            className="flex snap-x snap-mandatory overflow-x-auto overflow-y-hidden overscroll-x-contain"
+            style={{ WebkitOverflowScrolling: "touch", touchAction: "pan-x", gap: 0, height: innerH }}
         >
             {rounds.map((column, r) => {
                 const locked = isRoundLocked(column)
@@ -155,6 +168,7 @@ function MobileCarousel({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): Re
                 )
             })}
             <div className="shrink-0" style={{ width: 16 }} />
+        </div>
         </div>
     )
 }


### PR DESCRIPTION
The phone bracket carousel used a single overflow-auto container that
scrolled both axes at once, so a diagonal drag panned the tree freely in
every direction. Split it into two nested scrollers with complementary
touch-action: an outer pan-y container owns vertical scrolling (the whole
tree, connectors aligned) and an inner pan-x snap container owns
horizontal round-to-round swiping. The browser routes each gesture to the
single axis that allows it, so the user scrolls up/down freely but only
swipes left/right between rounds.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbcgNswDhGPoNGFvC8V5W7