### PR TITLE
Project knockout bracket forward from picks and seat ties by feeder

### DIFF
--- a/frontend/app/util/__tests__/bracket-layout.test.ts
+++ b/frontend/app/util/__tests__/bracket-layout.test.ts
@@ -16,10 +16,26 @@ function r32Match(position: number, overrides: Partial<LayoutMatch> = {}): Layou
     }
 }
 
+function r16Match(home: string, away: string, overrides: Partial<LayoutMatch> = {}): LayoutMatch {
+    return {
+        round: r16,
+        state: "UPCOMING",
+        homeTeam: home,
+        homeTeamFlagCode: "h",
+        awayTeam: away,
+        awayTeamFlagCode: "a",
+        ...overrides,
+    }
+}
+
 function placeholders(slots: Slot<LayoutMatch>[]): Array<{ home?: string; away?: string }> {
     return slots
         .filter((s): s is Extract<Slot<LayoutMatch>, { kind: "placeholder" }> => s.kind === "placeholder")
         .map((s) => ({ home: s.home?.name, away: s.away?.name }))
+}
+
+function roundSlots(rounds: ReturnType<typeof buildBracket>, round: typeof r16): Slot<LayoutMatch>[] {
+    return rounds.find((c) => c.round === round)!.slots
 }
 
 describe("buildBracket", () => {
@@ -67,9 +83,50 @@ describe("buildBracket", () => {
         expect(r16Slots[0]).toEqual({ home: "Away 1", away: "Home 2" })
     })
 
-    it("leaves a slot empty until at least one feeder completes", () => {
+    it("leaves a slot empty until at least one feeder is decided or predicted", () => {
         const rounds = buildBracket([r32Match(1), r32Match(2)])
         const r16Slots = placeholders(rounds.find((c) => c.round === r16)!.slots)
         expect(r16Slots[0]).toEqual({ home: undefined, away: undefined })
+    })
+
+    it("partially fills the fed slot from the user's pick before the feeders complete", () => {
+        // Both feeders are still upcoming, but the user has backed a side in each.
+        const rounds = buildBracket([
+            r32Match(1, { userPick: "HOME" }),
+            r32Match(2, { userPick: "AWAY" }),
+        ])
+        const r16Slots = placeholders(roundSlots(rounds, r16))
+        expect(r16Slots[0]).toEqual({ home: "Home 1", away: "Away 2" })
+    })
+
+    it("prefers the actual qualifier over the user's pick once a feeder is decided", () => {
+        const rounds = buildBracket([
+            r32Match(1, { state: "COMPLETED", actualGoThrough: "AWAY", userPick: "HOME" }),
+            r32Match(2, { userPick: "HOME" }),
+        ])
+        const r16Slots = placeholders(roundSlots(rounds, r16))
+        expect(r16Slots[0]).toEqual({ home: "Away 1", away: "Home 2" })
+    })
+
+    it("seats a full Round of 16 tie beneath the feeders that produce it", () => {
+        // Slots 0/1 of R32 feed R16 slot 0; slots 2/3 feed R16 slot 1. The two
+        // real R16 ties are supplied out of order to prove they're placed by feed,
+        // not by kickoff order.
+        const slotZero = r16Match("Away 1", "Home 2")
+        const slotOne = r16Match("Home 3", "Away 4")
+        const rounds = buildBracket([
+            r32Match(1), r32Match(2), r32Match(3), r32Match(4),
+            slotOne, slotZero,
+        ])
+        const r16Slots = roundSlots(rounds, r16)
+        expect(r16Slots[0]).toMatchObject({ kind: "match", match: { homeTeam: "Away 1" } })
+        expect(r16Slots[1]).toMatchObject({ kind: "match", match: { homeTeam: "Home 3" } })
+    })
+
+    it("falls back to kickoff order for a real tie whose feeders aren't known yet", () => {
+        // No R32 matches, so no feeders can supply the R16 tie's teams.
+        const tie = r16Match("England", "France")
+        const r16Slots = roundSlots(buildBracket([tie]), r16)
+        expect(r16Slots[0]).toMatchObject({ kind: "match", match: { homeTeam: "England" } })
     })
 })

--- a/frontend/app/util/bracket-layout.ts
+++ b/frontend/app/util/bracket-layout.ts
@@ -2,10 +2,13 @@
  * Pure geometry/derivation for the Knockout Cup bracket tree.
  *
  * Groups a user's knockout matches into the full single-elimination tree (every
- * round padded to its expected size with TBD placeholders) and, where a match's
- * feeder results are already known, fills the next round's empty slots with the
- * teams that went through. Kept free of React and the generated client so it can
- * be unit-tested in isolation (see `__tests__/bracket-layout.test.ts`).
+ * round padded to its expected size with TBD placeholders) and projects the
+ * run forward through the empty rounds: each slot is filled from the side that
+ * actually went through, or — before the feeders are decided — the side the
+ * user backed to go through (their `toGoThrough` pick). When a real next-round
+ * match already exists, it's seated in the slot its two feeders point to rather
+ * than dumped in kickoff order. Kept free of React and the generated client so
+ * it can be unit-tested in isolation (see `__tests__/bracket-layout.test.ts`).
  */
 
 import { BracketRound, GoThrough, KNOCKOUT_ROUNDS } from "./bracket-scoring"
@@ -27,6 +30,8 @@ export interface LayoutMatch {
     homeTeamFlagCode: string
     awayTeam: string
     awayTeamFlagCode: string
+    /** The side the user backed to go through — projects the run forward before a result lands. */
+    userPick?: GoThrough
     actualGoThrough?: GoThrough
     bracketPosition?: number | null
 }
@@ -50,20 +55,51 @@ export interface RoundColumn<M> {
     slots: Slot<M>[]
 }
 
-/** The side that went through a completed match, or undefined while undecided. */
-function winnerOf(match: LayoutMatch): DerivedTeam | undefined {
-    if (match.state !== "COMPLETED" || match.actualGoThrough == null) return undefined
-    return match.actualGoThrough === "HOME"
+/**
+ * The team a slot sends to the round it feeds: the side that actually went
+ * through once the match is decided, otherwise the side the user backed to go
+ * through (their `toGoThrough` pick). A placeholder is an unplayed, unpredicted
+ * match, so it forwards nothing.
+ */
+function projectedTeam<M extends LayoutMatch>(slot: Slot<M> | undefined): DerivedTeam | undefined {
+    if (slot == null || slot.kind !== "match") return undefined
+    const match = slot.match
+    const side = match.state === "COMPLETED" ? match.actualGoThrough ?? match.userPick : match.userPick
+    if (side == null) return undefined
+    return side === "HOME"
         ? { name: match.homeTeam, flag: match.homeTeamFlagCode }
         : { name: match.awayTeam, flag: match.awayTeamFlagCode }
+}
+
+/** The teams a slot could supply downstream — both sides of a real tie, or whatever a placeholder has so far. */
+function slotTeams<M extends LayoutMatch>(slot: Slot<M> | undefined): string[] {
+    if (slot == null) return []
+    if (slot.kind === "match") return [slot.match.homeTeam, slot.match.awayTeam]
+    return [slot.home?.name, slot.away?.name].filter((name): name is string => name != null)
+}
+
+/** Does this real match's two teams come from this pair of feeder slots, one from each? */
+function feedsFrom<M extends LayoutMatch>(match: M, a: Slot<M> | undefined, b: Slot<M> | undefined): boolean {
+    if (a == null || b == null) return false
+    const fromA = slotTeams(a)
+    const fromB = slotTeams(b)
+    return (
+        (fromA.includes(match.homeTeam) && fromB.includes(match.awayTeam)) ||
+        (fromA.includes(match.awayTeam) && fromB.includes(match.homeTeam))
+    )
 }
 
 /**
  * Build the full bracket: every knockout round, ordered by bracket position and
  * padded to its expected size with placeholders. Consecutive pairs (2j, 2j+1)
- * feed slot j of the next round, so any completed feeder's winner is carried
- * forward into the (otherwise empty) slot it feeds — partially filling a slot
- * when one feeder is decided, fully when both are.
+ * feed slot j of the next round. Each next-round slot is resolved in order:
+ *
+ *  1. A real match is seated beneath the feeder pair that produces its two teams,
+ *     so a known fixture lands in the right place however the feeders are ordered.
+ *  2. Any real match we can't seat that way (teams not yet known upstream) falls
+ *     into the next free slot, preserving kickoff order.
+ *  3. Remaining slots become placeholders, partially filled from the teams
+ *     projected to feed them — the actual qualifiers, else the user's picks.
  */
 export function buildBracket<M extends LayoutMatch>(matches: M[]): RoundColumn<M>[] {
     const byRound = new Map<BracketRound, M[]>()
@@ -73,32 +109,46 @@ export function buildBracket<M extends LayoutMatch>(matches: M[]): RoundColumn<M
         else byRound.set(match.round, [match])
     }
 
-    const columns: RoundColumn<M>[] = KNOCKOUT_ROUNDS.map((round) => {
+    const columns: RoundColumn<M>[] = []
+    let prev: Slot<M>[] | null = null
+
+    for (const round of KNOCKOUT_ROUNDS) {
+        const size = ROUND_SIZES[round]
         // Order by bracket position so consecutive pairs feed the right next-round
         // slot; matches without a position keep their incoming (kickoff) order.
-        const real = [...(byRound.get(round) ?? [])].sort(
+        const remaining = [...(byRound.get(round) ?? [])].sort(
             (a, b) => (a.bracketPosition ?? Infinity) - (b.bracketPosition ?? Infinity),
         )
-        const slots: Slot<M>[] = real.map((match): Slot<M> => ({ kind: "match", match }))
-        for (let i = slots.length; i < ROUND_SIZES[round]; i++) {
-            slots.push({ kind: "placeholder", id: `${round}-ph-${i}` })
-        }
-        return { round, slots }
-    })
+        const slots: Slot<M>[] = new Array<Slot<M>>(size)
 
-    // Carry feeder winners forward, round by round, into the slots they feed.
-    let prevWinners: (DerivedTeam | undefined)[] | null = null
-    for (const column of columns) {
-        const winners = column.slots.map((slot, j): DerivedTeam | undefined => {
-            if (slot.kind === "match") return winnerOf(slot.match)
-            if (prevWinners) {
-                slot.home = prevWinners[2 * j]
-                slot.away = prevWinners[2 * j + 1]
+        // 1. Seat real matches beneath the feeders that produce them.
+        if (prev) {
+            for (let j = 0; j < size; j++) {
+                const idx = remaining.findIndex((match) => feedsFrom(match, prev![2 * j], prev![2 * j + 1]))
+                if (idx !== -1) slots[j] = { kind: "match", match: remaining.splice(idx, 1)[0] }
             }
-            // A placeholder is an unplayed match: it never has a winner to forward.
-            return undefined
-        })
-        prevWinners = winners
+        }
+
+        // 2. Seat any leftover real matches in the next free slot.
+        for (const match of remaining) {
+            const j = slots.findIndex((slot) => slot == null)
+            if (j === -1) break
+            slots[j] = { kind: "match", match }
+        }
+
+        // 3. Fill the rest with placeholders, carrying the projected feeders forward.
+        for (let j = 0; j < size; j++) {
+            if (slots[j] != null) continue
+            slots[j] = {
+                kind: "placeholder",
+                id: `${round}-ph-${j}`,
+                home: prev ? projectedTeam(prev[2 * j]) : undefined,
+                away: prev ? projectedTeam(prev[2 * j + 1]) : undefined,
+            }
+        }
+
+        columns.push({ round, slots })
+        prev = slots
     }
 
     return columns


### PR DESCRIPTION
Two front-end-only changes to the Knockout Cup bracket layout (`bracket-layout.ts`):

- Partial completion from `toGoThrough`: future-round slots now fill from the side actually through once decided, else the side the user backed to go through (their pick) — projecting the predicted path forward through every empty round instead of only filling on a completed feeder.

- Smart placement: a real Round-of-16-onward match is seated beneath the feeder pair that produces its two teams (by team membership), so a known fixture lands in the right slot however the feeders are ordered. Matches whose feeders aren't known yet fall back to kickoff order.

Adds unit tests for pick-based partial fill, actual-over-pick precedence, out-of-order tie seating, and the kickoff-order fallback.