### PR TITLE
Record penalty-shootout winner as the knockout go-through

### DIFF
--- a/lambdas/src/main/kotlin/scorcerer/server/schedule/ScoreUpdater.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/schedule/ScoreUpdater.kt
@@ -10,6 +10,7 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import org.openapitools.server.models.Match
+import scorcerer.server.db.tables.MatchResult
 import scorcerer.server.db.tables.MatchRound
 import scorcerer.server.db.tables.MatchTable
 import scorcerer.server.db.tables.TeamTable
@@ -37,7 +38,13 @@ import java.time.temporal.ChronoUnit
 private data class EspnTeam(val displayName: String?, val abbreviation: String?)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-private data class EspnCompetitor(val homeAway: String?, val score: String?, val team: EspnTeam?)
+private data class EspnCompetitor(
+    val homeAway: String?,
+    val score: String?,
+    val team: EspnTeam?,
+    // Winner once final — set even on penalties (level score); both false on a draw.
+    val winner: Boolean?,
+)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 private data class EspnStatusType(val state: String?, val name: String?, val completed: Boolean?)
@@ -148,6 +155,14 @@ private fun roundFromSlug(slug: String?): MatchRound? = when (slug) {
     "semifinals" -> MatchRound.SEMI_FINAL
     "3rd-place-match" -> MatchRound.THIRD_PLACE_PLAYOFF
     "final" -> MatchRound.FINAL
+    else -> null
+}
+
+// Which side ESPN flags as progressing — the only signal that survives a penalty
+// shootout. Null when neither is flagged; endMatch then derives from the score.
+private fun goThroughFromEspn(home: EspnCompetitor, away: EspnCompetitor): MatchResult? = when {
+    home.winner == true -> MatchResult.HOME
+    away.winner == true -> MatchResult.AWAY
     else -> null
 }
 
@@ -312,7 +327,7 @@ class ScoreUpdater(
                         val matchDay = getMatchDay(match.matchId.toString()) ?: continue
                         setScore(match.matchId.toString(), matchDay, homeScore, awayScore, leaderboardService, tournamentStateService)
                     }
-                    endMatch(match.matchId.toString(), homeScore, awayScore, leaderboardService, tournamentStateService)
+                    endMatch(match.matchId.toString(), homeScore, awayScore, leaderboardService, tournamentStateService, goThroughFromEspn(homeC, awayC))
                     log.info("Match ${match.matchId}: ${match.state} -> COMPLETED ($homeScore-$awayScore)")
                     transitions++
                 }

--- a/lambdas/src/main/kotlin/scorcerer/server/services/MatchScoring.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/services/MatchScoring.kt
@@ -29,6 +29,8 @@ fun endMatch(
     awayScore: Int,
     leaderboardService: LeaderboardService,
     tournamentStateService: TournamentStateService = TournamentStateService(),
+    // Explicit go-through (e.g. ESPN's penalty-shootout winner); null = derive from score.
+    goThrough: scorcerer.server.db.tables.MatchResult? = null,
 ) = transaction {
     val matchDay = getMatchDay(matchId)
         ?: throw ApiResponseError(Response(Status.BAD_REQUEST).body("Match does not exist"))
@@ -43,10 +45,9 @@ fun endMatch(
         it[state] = Match.State.COMPLETED
         it[MatchTable.homeScore] = homeScore
         it[MatchTable.awayScore] = awayScore
-        // Record which side went through so the Knockout Cup can score the tie.
-        // A level score (group-stage draw, or a knockout decided on penalties we
-        // can't see) leaves it null; only knockout rounds read this column.
-        it[MatchTable.result] = goThroughFromScore(homeScore, awayScore)
+        // Which side went through, for the Knockout Cup. Prefer the explicit
+        // winner (penalty shootouts); else derive from score (null on a draw).
+        it[MatchTable.result] = goThrough ?: goThroughFromScore(homeScore, awayScore)
     }
 
     val pointsByMember = scorePredictions(matchId, homeScore, awayScore)

--- a/lambdas/src/main/kotlin/scorcerer/server/services/MatchScoring.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/services/MatchScoring.kt
@@ -15,13 +15,14 @@ import org.openapitools.server.models.Chip
 import org.openapitools.server.models.Match
 import org.openapitools.server.models.Prediction
 import scorcerer.server.ApiResponseError
+import scorcerer.server.db.tables.MatchResult
 import scorcerer.server.db.tables.MatchTable
 import scorcerer.server.db.tables.MemberTable
 import scorcerer.server.db.tables.PredictionTable
 import scorcerer.server.log
 import scorcerer.utils.LeaderboardService
-import scorcerer.utils.MatchResult
 import scorcerer.utils.PointsCalculator.calculatePoints
+import scorcerer.utils.MatchResult as Scoreline
 
 fun endMatch(
     matchId: String,
@@ -30,7 +31,7 @@ fun endMatch(
     leaderboardService: LeaderboardService,
     tournamentStateService: TournamentStateService = TournamentStateService(),
     // Explicit go-through (e.g. ESPN's penalty-shootout winner); null = derive from score.
-    goThrough: scorcerer.server.db.tables.MatchResult? = null,
+    goThrough: MatchResult? = null,
 ) = transaction {
     val matchDay = getMatchDay(matchId)
         ?: throw ApiResponseError(Response(Status.BAD_REQUEST).body("Match does not exist"))
@@ -178,16 +179,15 @@ fun recalculateAllFixedPoints() = transaction {
 
 // Who progresses, derived from the final score. Null on a level score: group-stage
 // draws never go through, and a knockout decided on penalties isn't distinguishable
-// from the scoreline alone. Returns the db `MatchResult` (HOME/AWAY), distinct from
-// the `scorcerer.utils.MatchResult` scoring helper used elsewhere in this file.
-private fun goThroughFromScore(homeScore: Int, awayScore: Int): scorcerer.server.db.tables.MatchResult? = when {
-    homeScore > awayScore -> scorcerer.server.db.tables.MatchResult.HOME
-    awayScore > homeScore -> scorcerer.server.db.tables.MatchResult.AWAY
+// from the scoreline alone.
+private fun goThroughFromScore(homeScore: Int, awayScore: Int): MatchResult? = when {
+    homeScore > awayScore -> MatchResult.HOME
+    awayScore > homeScore -> MatchResult.AWAY
     else -> null
 }
 
 private fun scorePredictions(matchId: String, homeScore: Int, awayScore: Int): Map<String, Int> {
-    val result = MatchResult(homeScore, awayScore)
+    val result = Scoreline(homeScore, awayScore)
     val predictions = getPredictions(matchId)
     val pointsByPrediction = predictions.associate { it.predictionId.toInt() to calculatePoints(it, result) }
     batchUpdatePredictionPoints(pointsByPrediction)

--- a/lambdas/src/test/kotlin/scorcerer/integration/MatchLifecycleTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/integration/MatchLifecycleTest.kt
@@ -235,6 +235,24 @@ class MatchLifecycleTest : PostgresTest() {
     }
 
     @Test
+    fun `penalty shootout records the explicit go-through over a level score`() {
+        val brazil = givenTeamExists("Brazil")
+        val germany = givenTeamExists("Germany")
+        val matchId = givenMatchExists(brazil, germany, matchDay = 1)
+
+        setScore(matchId, 1, 1, 1, leaderboardService)
+        // Level 1-1, but away won on penalties — endMatch is given the explicit
+        // go-through (as ScoreUpdater does from ESPN's winner flag).
+        endMatch(matchId, 1, 1, leaderboardService, goThrough = scorcerer.server.db.tables.MatchResult.AWAY)
+        transaction {
+            MatchTable.selectAll().where { MatchTable.id eq matchId.toInt() }.first().let {
+                it[MatchTable.state] shouldBe Match.State.COMPLETED
+                it[MatchTable.result] shouldBe scorcerer.server.db.tables.MatchResult.AWAY
+            }
+        }
+    }
+
+    @Test
     fun `prediction points persist correctly through score changes`() {
         val brazil = givenTeamExists("Brazil")
         val germany = givenTeamExists("Germany")

--- a/lambdas/src/test/kotlin/scorcerer/integration/MatchLifecycleTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/integration/MatchLifecycleTest.kt
@@ -14,6 +14,7 @@ import scorcerer.givenPredictionExists
 import scorcerer.givenTeamExists
 import scorcerer.givenUserExists
 import scorcerer.givenUserInLeague
+import scorcerer.server.db.tables.MatchResult
 import scorcerer.server.db.tables.MatchTable
 import scorcerer.server.db.tables.MemberTable
 import scorcerer.server.db.tables.PredictionTable
@@ -218,7 +219,7 @@ class MatchLifecycleTest : PostgresTest() {
         transaction {
             MatchTable.selectAll().where { MatchTable.id eq matchId.toInt() }.first().let {
                 it[MatchTable.state] shouldBe Match.State.COMPLETED
-                it[MatchTable.result] shouldBe scorcerer.server.db.tables.MatchResult.HOME
+                it[MatchTable.result] shouldBe MatchResult.HOME
             }
         }
 
@@ -243,11 +244,11 @@ class MatchLifecycleTest : PostgresTest() {
         setScore(matchId, 1, 1, 1, leaderboardService)
         // Level 1-1, but away won on penalties — endMatch is given the explicit
         // go-through (as ScoreUpdater does from ESPN's winner flag).
-        endMatch(matchId, 1, 1, leaderboardService, goThrough = scorcerer.server.db.tables.MatchResult.AWAY)
+        endMatch(matchId, 1, 1, leaderboardService, goThrough = MatchResult.AWAY)
         transaction {
             MatchTable.selectAll().where { MatchTable.id eq matchId.toInt() }.first().let {
                 it[MatchTable.state] shouldBe Match.State.COMPLETED
-                it[MatchTable.result] shouldBe scorcerer.server.db.tables.MatchResult.AWAY
+                it[MatchTable.result] shouldBe MatchResult.AWAY
             }
         }
     }


### PR DESCRIPTION
Knockout matches decided on penalties have a level score, so goThroughFromScore returned null and MatchTable.result was never populated — leaving the Knockout Cup without a winner for those ties.

ESPN's scoreboard API flags exactly one competitor with winner=true once a fixture is final, including penalty shootouts. Read that flag in ScoreUpdater and pass it to endMatch, which now prefers an explicit go-through and falls back to deriving from the score (so the manual admin endpoint is unchanged).