### PR TITLE
Show the real knockout bracket on the standings page

### DIFF
--- a/frontend/app/app/standings/page.tsx
+++ b/frontend/app/app/standings/page.tsx
@@ -6,8 +6,10 @@ import {PitchPerspective} from "@/app/components/atmosphere"
 import ThirdPlacedTable from "@/app/components/standings/third-placed-table"
 import StandingsRefresher from "@/app/components/standings/standings-refresher"
 import StandingsGroups from "@/app/components/standings/standings-groups"
+import BracketTree from "@/app/components/bracket/bracket-tree"
 import type {GroupMatch} from "@/app/components/flags/group-venue-map"
 import {buildTeamGroupMap} from "@/app/util/group-matches"
+import {getBracket} from "@/app/api/bracket"
 
 export const dynamic = "force-dynamic"
 
@@ -56,14 +58,19 @@ export default async function StandingsPage(
     const initialGroup = typeof groupParam === "string" ? groupParam : undefined
     const config = await getConfigWithAuthHeader()
     const matchApi = new MatchApi(config)
-    const [standings, liveMatches, upcomingMatches, completedMatches] = await Promise.all([
+    const [standings, liveMatches, upcomingMatches, completedMatches, bracket] = await Promise.all([
         new StandingsApi(config).getStandings().catch((): Standings => ({groups: [], thirdPlaced: []})),
         matchApi.listMatches({filterType: ListMatchesFilterTypeEnum.Live}).catch((): Match[] => []),
         matchApi.listMatches({filterType: ListMatchesFilterTypeEnum.Upcoming}).catch((): Match[] => []),
         matchApi.listMatches({filterType: ListMatchesFilterTypeEnum.Completed}).catch((): Match[] => []),
+        getBracket(),
     ])
     const hasLiveMatch = liveMatches.length > 0
     const matchesByGroup = bucketMatchesByGroup(standings.groups, [...liveMatches, ...upcomingMatches, ...completedMatches])
+    // The bracket endpoint carries the user's picks too, but the standings page
+    // shows the tournament as it really stands, so BracketTree renders it in
+    // results-only mode. Hidden until the knockouts actually have fixtures.
+    const knockoutMatches = bracket?.matches ?? []
 
     return (
         <main className="relative min-h-svh bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-x-clip">
@@ -112,6 +119,19 @@ export default async function StandingsPage(
                             </div>
                         </section>
                     </>
+                )}
+
+                {knockoutMatches.length > 0 && (
+                    <section className="space-y-4">
+                        <div className="flex flex-col items-center text-center">
+                            <p className="text-xs font-bold uppercase tracking-[0.25em] text-slate-500 dark:text-gray-400">Knockouts</p>
+                            <h2 className="mt-0.5 text-2xl font-black tracking-tight text-slate-900 dark:text-white">Bracket</h2>
+                            <p className="mt-1 max-w-md text-sm text-slate-500 dark:text-gray-400">
+                                The road to the final, filled in as results come in.
+                            </p>
+                        </div>
+                        <BracketTree matches={knockoutMatches} resultsOnly/>
+                    </section>
                 )}
 
                 <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pb-8 text-xs text-slate-500 dark:text-gray-400">

--- a/frontend/app/components/bracket/bracket-cell.tsx
+++ b/frontend/app/components/bracket/bracket-cell.tsx
@@ -24,19 +24,29 @@ interface BracketCellProps {
     /** Predictions for this match aren't open yet (a future round). */
     locked: boolean
     dims: CellDims
+    /**
+     * Show only the real result (which side went through) with no pick overlay —
+     * used by the standings page's tournament bracket, where a personal run makes
+     * no sense. Suppresses the backed-side accent, the points, and the padlock.
+     */
+    resultsOnly?: boolean
 }
 
 /**
  * A single match cell in the bracket tree: the two teams stacked, the side the
  * user backed accented (and coloured by outcome once decided), the side that
  * actually went through ticked, and the points the pick earned. Locked matches
- * (a round you can't predict yet) are greyed out and show a padlock.
+ * (a round you can't predict yet) are greyed out and show a padlock. In
+ * `resultsOnly` mode the pick overlay is dropped and only the real result shows.
  */
-export default function BracketCell({ match, locked, dims }: BracketCellProps): React.JSX.Element {
+export default function BracketCell({ match, locked, dims, resultsOnly = false }: BracketCellProps): React.JSX.Element {
     const completed = !locked && match.state === "COMPLETED" && match.actualGoThrough != null
     const points = match.basePoints + match.bonusPoints
     const flagSize = dims.compact ? 15 : 18
     const nameClass = dims.compact ? "text-[11px]" : "text-[12px]"
+    // In results mode there's no personal run, so ignore the user's pick entirely.
+    const userPick = resultsOnly ? undefined : match.userPick
+    const correct = resultsOnly ? undefined : match.correct
 
     const inner = (
         <div
@@ -49,15 +59,15 @@ export default function BracketCell({ match, locked, dims }: BracketCellProps): 
         >
             <TeamLine
                 side="HOME" name={match.homeTeam} flag={match.homeTeamFlagCode}
-                userPick={match.userPick} actual={completed ? match.actualGoThrough : undefined}
-                correct={match.correct} points={points} bonus={match.bonusPoints}
+                userPick={userPick} actual={completed ? match.actualGoThrough : undefined}
+                correct={correct} points={points} bonus={match.bonusPoints}
                 locked={locked} flagSize={flagSize} nameClass={nameClass}
             />
             <div className="h-px bg-slate-900/10 dark:bg-white/10" />
             <TeamLine
                 side="AWAY" name={match.awayTeam} flag={match.awayTeamFlagCode}
-                userPick={match.userPick} actual={completed ? match.actualGoThrough : undefined}
-                correct={match.correct} points={points} bonus={match.bonusPoints}
+                userPick={userPick} actual={completed ? match.actualGoThrough : undefined}
+                correct={correct} points={points} bonus={match.bonusPoints}
                 locked={locked} flagSize={flagSize} nameClass={nameClass}
             />
             {locked && (

--- a/frontend/app/components/bracket/bracket-tree.tsx
+++ b/frontend/app/components/bracket/bracket-tree.tsx
@@ -17,6 +17,12 @@ const SLOT = CARD_H + V_GAP
 
 interface BracketTreeProps {
     matches: BracketMatch[]
+    /**
+     * Render the real tournament bracket (results only) rather than the viewer's
+     * personal run: no pick accents, no points, no prediction padlocks. Used by
+     * the standings page.
+     */
+    resultsOnly?: boolean
 }
 
 function useCompact(): boolean {
@@ -52,20 +58,23 @@ function isRoundLocked(column: RoundColumn<BracketMatch>): boolean {
  * Matches that are in the bracket but not yet open for predictions are greyed out
  * and padlocked.
  */
-export default function BracketTree({ matches }: BracketTreeProps): React.JSX.Element {
+export default function BracketTree({ matches, resultsOnly = false }: BracketTreeProps): React.JSX.Element {
     const compact = useCompact()
     const rounds = buildBracket(matches)
 
     return compact
-        ? <MobileCarousel rounds={rounds} />
-        : <DesktopTree rounds={rounds} />
+        ? <MobileCarousel rounds={rounds} resultsOnly={resultsOnly} />
+        : <DesktopTree rounds={rounds} resultsOnly={resultsOnly} />
 }
 
-function renderSlot(slot: Slot<BracketMatch>, dims: CellDims): React.JSX.Element {
+function renderSlot(slot: Slot<BracketMatch>, dims: CellDims, resultsOnly: boolean): React.JSX.Element {
     if (slot.kind === "placeholder") {
         return <PlaceholderCell dims={dims} home={slot.home} away={slot.away} />
     }
-    return <BracketCell match={slot.match} locked={isMatchLocked(slot.match)} dims={dims} />
+    // The prediction padlock only makes sense for a personal run; the tournament
+    // bracket shows every known tie plainly.
+    const locked = resultsOnly ? false : isMatchLocked(slot.match)
+    return <BracketCell match={slot.match} locked={locked} dims={dims} resultsOnly={resultsOnly} />
 }
 
 function slotKey(slot: Slot<BracketMatch>): string {
@@ -88,7 +97,7 @@ function mobileCenters(matchCount: number, totalSlots: number): number[] {
 }
 
 /** Phone layout: snap-scroll carousel with proper bracket connector lines. */
-function MobileCarousel({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): React.JSX.Element {
+function MobileCarousel({ rounds, resultsOnly }: { rounds: RoundColumn<BracketMatch>[]; resultsOnly: boolean }): React.JSX.Element {
     const firstRoundCount = rounds[0].slots.length
     // Slot height × slot count gives the bounding box. We previously subtracted
     // M_V_GAP to avoid a trailing gap below the last cell, but mobileCenters()
@@ -141,7 +150,7 @@ function MobileCarousel({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): Re
                             style={{ ...colWidth, height: M_HEADER_H }}
                         >
                             {ROUND_LABELS[column.round]}
-                            {isRoundLocked(column) && <LockIcon className="h-3 w-3 text-slate-400 dark:text-gray-500" />}
+                            {!resultsOnly && isRoundLocked(column) && <LockIcon className="h-3 w-3 text-slate-400 dark:text-gray-500" />}
                         </div>
                     </React.Fragment>
                 ))}
@@ -193,7 +202,7 @@ function MobileCarousel({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): Re
                                             className="absolute w-full"
                                             style={{ top: centers[j] - M_CARD_H / 2 }}
                                         >
-                                            {renderSlot(slot, dims)}
+                                            {renderSlot(slot, dims, resultsOnly)}
                                         </div>
                                     ))}
                                 </section>
@@ -208,7 +217,7 @@ function MobileCarousel({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): Re
 }
 
 /** Desktop layout: the connected bracket tree. */
-function DesktopTree({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): React.JSX.Element {
+function DesktopTree({ rounds, resultsOnly }: { rounds: RoundColumn<BracketMatch>[]; resultsOnly: boolean }): React.JSX.Element {
     const dims: CellDims = { width: CARD_W, height: CARD_H, compact: false }
     const totalHeight = rounds[0].slots.length * SLOT
 
@@ -255,7 +264,7 @@ function DesktopTree({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): React
                             style={{ left: r * COL, width: CARD_W }}
                         >
                             {ROUND_SHORT_LABELS[column.round]}
-                            {isRoundLocked(column) && <LockIcon className="h-3 w-3 text-slate-400 dark:text-gray-500" />}
+                            {!resultsOnly && isRoundLocked(column) && <LockIcon className="h-3 w-3 text-slate-400 dark:text-gray-500" />}
                         </div>
                     ))}
                 </div>
@@ -273,7 +282,7 @@ function DesktopTree({ rounds }: { rounds: RoundColumn<BracketMatch>[] }): React
                                 className="absolute"
                                 style={{ left: r * COL, top: centers[r][j] - CARD_H / 2, width: CARD_W }}
                             >
-                                {renderSlot(slot, dims)}
+                                {renderSlot(slot, dims, resultsOnly)}
                             </div>
                         )),
                     )}


### PR DESCRIPTION
Reuse BracketTree/BracketCell from the Knockout Cup, adding a results-only
mode that drops the personal-run overlay (backed-side accents, points, and
prediction padlocks) and renders just the tournament as it really stands.
The standings page fetches the bracket and renders it in that mode below the
group tables, hidden until the knockouts have fixtures.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019KhYtSedtRLduVtTBDB6V5