### PR TITLE
Backfill knockout go-through when ESPN flags the winner after full-time

### DIFF
--- a/lambdas/src/main/kotlin/scorcerer/server/schedule/ScoreUpdater.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/schedule/ScoreUpdater.kt
@@ -18,9 +18,11 @@ import scorcerer.server.emitCount
 import scorcerer.server.fromJson
 import scorcerer.server.log
 import scorcerer.server.services.TournamentStateService
+import scorcerer.server.services.backfillGoThrough
 import scorcerer.server.services.endMatch
 import scorcerer.server.services.getMatchDay
 import scorcerer.server.services.setScore
+import scorcerer.utils.BracketScoring
 import scorcerer.utils.LeaderboardService
 import java.text.Normalizer
 import java.time.Duration
@@ -86,6 +88,9 @@ private data class ExistingMatch(
     val state: Match.State,
     val espnId: String?,
     val venue: String,
+    // Which side went through (for the Knockout Cup). Null when unknown — either
+    // a group draw or a knockout tie whose winner ESPN hasn't flagged yet.
+    val result: MatchResult?,
 )
 
 // ESPN team names that don't match our team table verbatim. Same alias map we
@@ -208,6 +213,7 @@ class ScoreUpdater(
                     state = it[MatchTable.state],
                     espnId = it[MatchTable.externalMatchId],
                     venue = it[MatchTable.venue],
+                    result = it[MatchTable.result],
                 )
             }
         }
@@ -322,7 +328,24 @@ class ScoreUpdater(
             // State transitions (same shape as before).
             when (state) {
                 "post" -> {
-                    if (match.state == Match.State.COMPLETED) continue
+                    if (match.state == Match.State.COMPLETED) {
+                        // Already completed, but a knockout tie may still be
+                        // missing its go-through: penalty shootouts report as
+                        // final (level score) a few ticks before ESPN flags the
+                        // winner, so the first "post" tick stored a null result.
+                        // Backfill it once the winner appears — otherwise the
+                        // Knockout Cup never scores the tie (no red/green pick,
+                        // and the streak never breaks on a wrong pick).
+                        if (round in BracketScoring.KNOCKOUT_ROUNDS && match.result == null) {
+                            val goThrough = goThroughFromEspn(homeC, awayC)
+                            if (goThrough != null) {
+                                backfillGoThrough(match.matchId.toString(), goThrough, tournamentStateService)
+                                log.info("Match ${match.matchId}: backfilled knockout go-through=$goThrough")
+                                transitions++
+                            }
+                        }
+                        continue
+                    }
                     if (match.state == Match.State.UPCOMING) {
                         val matchDay = getMatchDay(match.matchId.toString()) ?: continue
                         setScore(match.matchId.toString(), matchDay, homeScore, awayScore, leaderboardService, tournamentStateService)

--- a/lambdas/src/main/kotlin/scorcerer/server/services/MatchScoring.kt
+++ b/lambdas/src/main/kotlin/scorcerer/server/services/MatchScoring.kt
@@ -61,6 +61,30 @@ fun endMatch(
     tournamentStateService.invalidateCache()
 }
 
+// Record the Knockout Cup go-through on a match that completed without one.
+// A knockout tie decided on penalties has a level score, so the completing tick
+// can leave result null when ESPN hasn't yet flagged the winner; a later tick
+// calls this once the winner is known. Only a completed match still missing its
+// result is touched — the scoreline and prediction points were already finalised
+// when the match ended, so they're left untouched; only the go-through is filled.
+fun backfillGoThrough(
+    matchId: String,
+    goThrough: MatchResult,
+    tournamentStateService: TournamentStateService = TournamentStateService(),
+) = transaction {
+    val row = MatchTable.selectAll().where { MatchTable.id eq matchId.toInt() }.firstOrNull()
+        ?: throw ApiResponseError(Response(Status.BAD_REQUEST).body("Match does not exist"))
+    if (row[MatchTable.state] != Match.State.COMPLETED || row[MatchTable.result] != null) {
+        log.info("Not backfilling go-through for match $matchId (state=${row[MatchTable.state]}, result already set=${row[MatchTable.result] != null})")
+        return@transaction
+    }
+
+    MatchTable.update({ MatchTable.id eq matchId.toInt() }) {
+        it[result] = goThrough
+    }
+    tournamentStateService.invalidateCache()
+}
+
 fun setScore(
     matchId: String,
     matchDay: Int,

--- a/lambdas/src/test/kotlin/scorcerer/integration/MatchLifecycleTest.kt
+++ b/lambdas/src/test/kotlin/scorcerer/integration/MatchLifecycleTest.kt
@@ -15,9 +15,11 @@ import scorcerer.givenTeamExists
 import scorcerer.givenUserExists
 import scorcerer.givenUserInLeague
 import scorcerer.server.db.tables.MatchResult
+import scorcerer.server.db.tables.MatchRound
 import scorcerer.server.db.tables.MatchTable
 import scorcerer.server.db.tables.MemberTable
 import scorcerer.server.db.tables.PredictionTable
+import scorcerer.server.services.backfillGoThrough
 import scorcerer.server.services.endMatch
 import scorcerer.server.services.setScore
 import scorcerer.utils.LeaderboardS3Service
@@ -249,6 +251,69 @@ class MatchLifecycleTest : PostgresTest() {
             MatchTable.selectAll().where { MatchTable.id eq matchId.toInt() }.first().let {
                 it[MatchTable.state] shouldBe Match.State.COMPLETED
                 it[MatchTable.result] shouldBe MatchResult.AWAY
+            }
+        }
+    }
+
+    @Test
+    fun `backfills a knockout go-through onto a completed tie that ended without one`() {
+        val brazil = givenTeamExists("Brazil")
+        val germany = givenTeamExists("Germany")
+        // A knockout tie that completed level, before ESPN flagged the shootout
+        // winner — so it's COMPLETED but its go-through is still null. This is the
+        // state that leaves the Knockout Cup unable to score (or break a streak on)
+        // the tie.
+        val matchId = givenMatchExists(
+            brazil,
+            germany,
+            matchState = Match.State.COMPLETED,
+            homeScore = 1,
+            awayScore = 1,
+            round = MatchRound.ROUND_OF_THIRTY_TWO,
+        )
+        transaction {
+            MatchTable.selectAll().where { MatchTable.id eq matchId.toInt() }
+                .first()[MatchTable.result] shouldBe null
+        }
+
+        // A later tick sees ESPN's winner flag and backfills the go-through.
+        backfillGoThrough(matchId, MatchResult.AWAY)
+        transaction {
+            MatchTable.selectAll().where { MatchTable.id eq matchId.toInt() }
+                .first()[MatchTable.result] shouldBe MatchResult.AWAY
+        }
+    }
+
+    @Test
+    fun `backfill never clobbers a go-through that is already set`() {
+        val brazil = givenTeamExists("Brazil")
+        val germany = givenTeamExists("Germany")
+        val matchId = givenMatchExists(brazil, germany, matchDay = 1, round = MatchRound.ROUND_OF_THIRTY_TWO)
+
+        setScore(matchId, 1, 2, 1, leaderboardService)
+        endMatch(matchId, 2, 1, leaderboardService) // home go-through recorded
+
+        // A stale/mistaken backfill must not overwrite the decided go-through.
+        backfillGoThrough(matchId, MatchResult.AWAY)
+        transaction {
+            MatchTable.selectAll().where { MatchTable.id eq matchId.toInt() }
+                .first()[MatchTable.result] shouldBe MatchResult.HOME
+        }
+    }
+
+    @Test
+    fun `backfill does not touch a match that has not completed`() {
+        val brazil = givenTeamExists("Brazil")
+        val germany = givenTeamExists("Germany")
+        val matchId = givenMatchExists(brazil, germany, matchDay = 1, round = MatchRound.ROUND_OF_THIRTY_TWO)
+
+        setScore(matchId, 1, 1, 1, leaderboardService) // LIVE, not completed
+
+        backfillGoThrough(matchId, MatchResult.AWAY)
+        transaction {
+            MatchTable.selectAll().where { MatchTable.id eq matchId.toInt() }.first().let {
+                it[MatchTable.state] shouldBe Match.State.LIVE
+                it[MatchTable.result] shouldBe null
             }
         }
     }


### PR DESCRIPTION
A knockout tie decided on penalties has a level score, so a match can flip
to COMPLETED a few ScoreUpdater ticks before ESPN sets its winner flag. On
that first "post" tick both the winner flag and the score are inconclusive,
so MatchTable.result is stored null — and every later tick then hits the
`if (state == COMPLETED) continue` guard, so the winner flag that arrives
afterwards is never read and the go-through stays null forever.

That leaves the Knockout Cup unable to score the tie: the bracket's scoreRun
treats a completed-but-null match as still pending, so a wrong pick shows no
red (correct stays undefined) and, worse, never breaks the streak — inflating
every subsequent pick's bonus.

Fix: on an already-completed knockout match still missing its result, re-read
ESPN's winner flag and backfill the go-through once it appears. The new
backfillGoThrough service only touches a COMPLETED match whose result is still
null, leaving the finalised scoreline and prediction points untouched. This is
self-healing for the matches already stuck in prod.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R3S6bpUwxc4MjWH3jr3vm3