### PR TITLE
Match points pill colours to form pill colours

### DIFF
--- a/frontend/app/components/leaderboard/form-badge.tsx
+++ b/frontend/app/components/leaderboard/form-badge.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 
-function dotStyle(points: number | null): string {
+// Shared colour scale for a score, used by the recent-form dots here and the
+// points pill on match cards so the two always agree: gold for a doubled exact
+// score (10), amber for an exact score (5), indigo for a doubled outcome (4),
+// blue for the right outcome (2), muted grey otherwise.
+export function pointsColorClasses(points: number | null): string {
     if (points === 10) return "bg-gradient-to-br from-yellow-300 via-amber-400 to-yellow-500 text-yellow-900 shadow-sm shadow-amber-400/50"
     if (points === 5) return "bg-gradient-to-br from-amber-400 via-orange-400 to-yellow-400 text-amber-900"
     if (points === 4) return "bg-gradient-to-br from-blue-400 via-indigo-400 to-violet-400 text-white"
@@ -24,7 +28,7 @@ export default function FormBadge({form, highlightLatest = false}: {form: (numbe
     return (
         <div className="flex items-center gap-1">
             {ordered.map((pts, i) => (
-                <div key={i} className={`h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-black ${dotStyle(pts)} ${highlightLatest && i === latestIndex ? `ring-2 ${ringStyle(pts)} ring-offset-2 ring-offset-slate-50 dark:ring-offset-gray-900` : ""}`}>
+                <div key={i} className={`h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-black ${pointsColorClasses(pts)} ${highlightLatest && i === latestIndex ? `ring-2 ${ringStyle(pts)} ring-offset-2 ring-offset-slate-50 dark:ring-offset-gray-900` : ""}`}>
                     {pts ?? 0}
                 </div>
             ))}

--- a/frontend/app/components/predictions/chip-impact.tsx
+++ b/frontend/app/components/predictions/chip-impact.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import {Chip, Match, Prediction} from "@/client"
+import {pointsColorClasses} from "@/app/components/leaderboard/form-badge"
 
 const GLYPH: Partial<Record<Chip, string>> = {
     [Chip.DoublePoints]: "2×",
@@ -172,22 +173,16 @@ export function ChipBadge({glyph, muted = false, title, className = ""}: {
     )
 }
 
-// Points-pill colours, consistent with the recent-form dots on the profile:
-// gold for an exact score, cyan for the right outcome, muted otherwise.
-function pointsTone(points: number): string {
-    if (points === 5) return "bg-gradient-to-br from-blue-500 via-cyan-400 to-teal-300 text-gray-900"
-    if (points === 2) return "bg-cyan-500/20 border border-cyan-500/40 text-cyan-700 dark:text-cyan-300"
-    return "bg-slate-900/10 dark:bg-white/10 text-slate-500 dark:text-gray-400"
-}
-
 // Points a prediction has earned (final) or is currently worth (live), shown as
-// a rounded pill. Sizing is overridable via `className` for tighter contexts.
+// a rounded pill. Colours come from the shared points scale so the pill matches
+// the recent-form dots exactly (gold/amber/indigo/blue/grey). Sizing is
+// overridable via `className` for tighter contexts.
 export function PointsPill({points, className = "h-6 px-2.5 text-xs"}: {
     points: number
     className?: string
 }): React.JSX.Element {
     return (
-        <span className={`inline-flex items-center justify-center rounded-full font-black tabular-nums ${pointsTone(points)} ${className}`}>
+        <span className={`inline-flex items-center justify-center rounded-full font-black tabular-nums ${pointsColorClasses(points)} ${className}`}>
             {points} pts
         </span>
     )


### PR DESCRIPTION
The PointsPill only coloured 5- and 2-point scores, so a 4-point score
(a doubled outcome) fell through to grey while the recent-form dots
showed it in indigo. Extract the form dots' colour scale into a shared
pointsColorClasses helper and use it for both, so the pill now covers
10/5/4/2 and the two can't drift apart again.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K3sLgxDM8P2298YkeqrFsh