### PR TITLE
Refresh visual styling to feel less generic

### DIFF
--- a/frontend/app/components/auth-shell.tsx
+++ b/frontend/app/components/auth-shell.tsx
@@ -10,7 +10,7 @@ interface AuthShellProps {
 export default function AuthShell({title, children}: AuthShellProps): React.JSX.Element {
     return (
         <section className="relative min-h-svh bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-hidden">
-            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.08),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.06),transparent_55%)] dark:bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.18),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.12),transparent_55%)]"/>
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(99,102,241,0.06),transparent_60%)] dark:bg-[radial-gradient(ellipse_at_top,rgba(99,102,241,0.12),transparent_60%)]"/>
 
             <div
                 className="pointer-events-none absolute inset-0 opacity-25 dark:opacity-40 [mask-image:radial-gradient(ellipse_at_center,black_30%,transparent_75%)]"
@@ -26,7 +26,7 @@ export default function AuthShell({title, children}: AuthShellProps): React.JSX.
             <div className="relative flex flex-col items-center justify-center px-6 py-12 min-h-svh">
                 <Link href="/" className="group flex items-center mb-8">
                     <span className="font-display flex items-baseline font-black tracking-tight text-lg">
-                        <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">
+                        <span className="text-indigo-600 dark:text-indigo-400">
                             predicta
                         </span>
                         <span className="text-slate-900 dark:text-white">ball</span>
@@ -34,8 +34,8 @@ export default function AuthShell({title, children}: AuthShellProps): React.JSX.
                     </span>
                 </Link>
 
-                <div className="relative w-full max-w-md rounded-2xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px]">
-                    <div className="rounded-2xl bg-white dark:bg-gray-900/80 backdrop-blur-xl p-6 sm:p-8">
+                <div className="relative w-full max-w-md rounded-xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 dark:from-white/15 dark:to-white/5 p-[1px]">
+                    <div className="rounded-xl bg-white dark:bg-gray-900/80 backdrop-blur-xl p-6 sm:p-8">
                         <h1 className="text-2xl font-black tracking-tight text-center mb-6">
                             {title}
                         </h1>

--- a/frontend/app/components/landing-header-login-button.tsx
+++ b/frontend/app/components/landing-header-login-button.tsx
@@ -6,12 +6,12 @@ interface LandingHeaderLoginButtonProps {
 
 export default function LandingHeaderLoginButton({buttonText = "Sign In"}: LandingHeaderLoginButtonProps) {
     return (
-        <div className="group relative inline-flex rounded-full bg-gradient-to-r from-blue-600 via-cyan-400 to-teal-300 p-[1.5px] shadow-lg shadow-cyan-500/10 transition-all hover:shadow-cyan-500/30 hover:scale-105">
+        <div className="group relative inline-flex rounded-full bg-gradient-to-r from-blue-600 via-cyan-400 to-teal-300 p-[1.5px] shadow-lg shadow-indigo-500/10 transition-all hover:shadow-indigo-500/30">
             <span className="rounded-full bg-white dark:bg-gray-900 font-semibold tracking-wide whitespace-nowrap px-5 h-9 min-w-0 group-hover:bg-slate-100 dark:group-hover:bg-gray-900/80 inline-flex items-center gap-1">
-                <span className="bg-gradient-to-r from-blue-500 via-cyan-500 to-teal-500 dark:from-blue-400 dark:via-cyan-300 dark:to-teal-300 bg-clip-text text-transparent">
+                <span className="text-indigo-600 dark:text-indigo-400">
                     {buttonText}
                 </span>
-                <span className="text-cyan-600 dark:text-cyan-300 transition-transform group-hover:translate-x-0.5">→</span>
+                <span className="text-indigo-600 dark:text-indigo-400 transition-transform group-hover:translate-x-0.5">→</span>
             </span>
         </div>
     )

--- a/frontend/app/components/landing-header.tsx
+++ b/frontend/app/components/landing-header.tsx
@@ -8,7 +8,7 @@ export function Header(): React.JSX.Element {
         <div className="w-full max-w-[800px] flex justify-between items-center">
             <Link href="/" className="group flex items-center gap-2">
                 <span className="font-display flex items-baseline font-black tracking-tight">
-                    <span className="text-lg bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">
+                    <span className="text-lg text-indigo-600 dark:text-indigo-400">
                         predicta
                     </span>
                     <span className="text-lg text-slate-900 dark:text-white">ball</span>

--- a/frontend/app/components/landing/how-it-works.tsx
+++ b/frontend/app/components/landing/how-it-works.tsx
@@ -13,7 +13,7 @@ export default function HowItWorks({children, compact}: {children?: React.ReactN
             <div className={`flex flex-col items-center text-center ${compact ? "mb-12" : "mb-20"}`}>
                 <span className="text-xs font-semibold tracking-[0.3em] text-cyan-600/90 dark:text-cyan-300/80 uppercase mb-4">How it works</span>
                 <h2 className={`font-display ${primaryHeading} font-black tracking-tight`}>
-                    <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">
+                    <span className="text-indigo-600 dark:text-indigo-400">
                         Predict every game.
                     </span>
                     <br/>
@@ -25,9 +25,9 @@ export default function HowItWorks({children, compact}: {children?: React.ReactN
             </div>
 
             <div className="grid md:grid-cols-3 gap-6">
-                <div className="group relative rounded-2xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
-                    <div className="relative h-full rounded-2xl bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
-                        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600/30 to-cyan-400/20 ring-1 ring-cyan-400/30 text-2xl mb-5">
+                <div className="group relative rounded-xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
+                    <div className="relative h-full rounded-[11px] bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-br from-blue-600/30 to-cyan-400/20 ring-1 ring-cyan-400/30 text-2xl mb-5">
                             &#128526;
                         </div>
                         <h3 className="text-xl font-bold mb-2 tracking-tight">The Prize</h3>
@@ -35,9 +35,9 @@ export default function HowItWorks({children, compact}: {children?: React.ReactN
                     </div>
                 </div>
 
-                <div className="group relative rounded-2xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
-                    <div className="relative h-full rounded-2xl bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
-                        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-cyan-500/30 to-teal-400/20 ring-1 ring-cyan-400/30 text-2xl mb-5">
+                <div className="group relative rounded-xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
+                    <div className="relative h-full rounded-[11px] bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-br from-cyan-500/30 to-teal-400/20 ring-1 ring-cyan-400/30 text-2xl mb-5">
                             &#127942;
                         </div>
                         <h3 className="text-xl font-bold mb-2 tracking-tight">Leagues</h3>
@@ -45,9 +45,9 @@ export default function HowItWorks({children, compact}: {children?: React.ReactN
                     </div>
                 </div>
 
-                <div className="group relative rounded-2xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
-                    <div className="relative h-full rounded-2xl bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
-                        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-green-500/30 to-emerald-400/20 ring-1 ring-green-400/30 text-2xl mb-5">
+                <div className="group relative rounded-xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
+                    <div className="relative h-full rounded-[11px] bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-br from-violet-500/30 to-indigo-400/20 ring-1 ring-violet-400/30 text-2xl mb-5">
                             &#129306;
                         </div>
                         <h3 className="text-xl font-bold mb-2 tracking-tight">Scoring</h3>
@@ -70,7 +70,7 @@ export default function HowItWorks({children, compact}: {children?: React.ReactN
                 <span className="text-xs font-semibold tracking-[0.3em] text-cyan-600/90 dark:text-cyan-300/80 uppercase mb-4">Power-ups</span>
                 <h2 className={`font-display ${secondaryHeading} font-black tracking-tight`}>
                     <span className="text-slate-900 dark:text-white">Play your </span>
-                    <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">chips</span>
+                    <span className="text-indigo-600 dark:text-indigo-400">chips</span>
                     <span className="text-slate-900 dark:text-white"> wisely.</span>
                 </h2>
                 <p className="mt-8 max-w-2xl text-lg text-slate-600 dark:text-gray-300 leading-relaxed">
@@ -79,9 +79,9 @@ export default function HowItWorks({children, compact}: {children?: React.ReactN
             </div>
 
             <div className="grid md:grid-cols-3 gap-6">
-                <div className="group relative rounded-2xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
-                    <div className="relative h-full rounded-2xl bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
-                        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600/30 to-cyan-400/20 ring-1 ring-cyan-400/30 font-black text-cyan-600 dark:text-cyan-300 mb-5">
+                <div className="group relative rounded-xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
+                    <div className="relative h-full rounded-[11px] bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-br from-blue-600/30 to-cyan-400/20 ring-1 ring-cyan-400/30 font-black text-cyan-600 dark:text-cyan-300 mb-5">
                             2&times;
                         </div>
                         <h3 className="text-xl font-bold mb-2 tracking-tight">Double Points</h3>
@@ -89,9 +89,9 @@ export default function HowItWorks({children, compact}: {children?: React.ReactN
                     </div>
                 </div>
 
-                <div className="group relative rounded-2xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
-                    <div className="relative h-full rounded-2xl bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
-                        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-cyan-500/30 to-teal-400/20 ring-1 ring-cyan-400/30 font-black text-cyan-600 dark:text-cyan-300 mb-5">
+                <div className="group relative rounded-xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
+                    <div className="relative h-full rounded-[11px] bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-br from-cyan-500/30 to-teal-400/20 ring-1 ring-cyan-400/30 font-black text-cyan-600 dark:text-cyan-300 mb-5">
                             &plusmn;1
                         </div>
                         <h3 className="text-xl font-bold mb-2 tracking-tight">Off by One</h3>
@@ -99,9 +99,9 @@ export default function HowItWorks({children, compact}: {children?: React.ReactN
                     </div>
                 </div>
 
-                <div className="group relative rounded-2xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
-                    <div className="relative h-full rounded-2xl bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
-                        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-green-500/30 to-emerald-400/20 ring-1 ring-green-400/30 font-black text-cyan-600 dark:text-cyan-300 mb-5">
+                <div className="group relative rounded-xl bg-gradient-to-br from-slate-900/10 to-slate-900/5 dark:from-white/10 dark:to-white/5 p-[1px] transition-transform hover:-translate-y-1">
+                    <div className="relative h-full rounded-[11px] bg-white dark:bg-gray-900/80 backdrop-blur-sm p-8 flex flex-col">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-br from-violet-500/30 to-indigo-400/20 ring-1 ring-violet-400/30 font-black text-cyan-600 dark:text-cyan-300 mb-5">
                             %
                         </div>
                         <h3 className="text-xl font-bold mb-2 tracking-tight">Follow the Crowd</h3>

--- a/frontend/app/components/surface-card.tsx
+++ b/frontend/app/components/surface-card.tsx
@@ -19,8 +19,8 @@ interface SurfaceCardProps {
  */
 export default function SurfaceCard({children, className = "", innerClassName = ""}: SurfaceCardProps): React.JSX.Element {
     return (
-        <div className={`relative rounded-3xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 p-[1px] shadow-xl shadow-slate-900/5 transition-shadow duration-300 hover:shadow-2xl hover:shadow-cyan-500/10 dark:from-white/15 dark:to-white/5 dark:shadow-cyan-500/5 dark:hover:shadow-cyan-500/15 ${className}`}>
-            <div className={`rounded-3xl bg-white/60 backdrop-blur-sm dark:bg-white/[0.03] ${innerClassName || "p-5 sm:p-6"}`}>
+        <div className={`relative rounded-xl bg-gradient-to-br from-slate-900/15 to-slate-900/5 p-[1px] shadow-xl shadow-slate-900/5 transition-shadow duration-300 hover:shadow-2xl hover:shadow-indigo-500/10 dark:from-white/15 dark:to-white/5 dark:shadow-indigo-500/5 dark:hover:shadow-indigo-500/15 ${className}`}>
+            <div className={`rounded-[11px] bg-white/60 backdrop-blur-sm dark:bg-white/[0.03] ${innerClassName || "p-5 sm:p-6"}`}>
                 {children}
             </div>
         </div>

--- a/frontend/app/components/wordmark.tsx
+++ b/frontend/app/components/wordmark.tsx
@@ -7,14 +7,15 @@ interface WordmarkProps {
 }
 
 /**
- * The predicta·ball·.LIVE wordmark. Single source of truth so the gradient,
+ * The predicta·ball·.LIVE wordmark. Single source of truth so the colour,
  * weights and the .LIVE suffix stay identical everywhere it appears (app header,
- * every sub-page header, etc.).
+ * every sub-page header, etc.). A solid brand-indigo "predicta" reads as a
+ * deliberate logotype rather than the ubiquitous gradient-text treatment.
  */
 export default function Wordmark({className = ""}: WordmarkProps): React.JSX.Element {
     return (
         <Link href="/" className={`flex items-baseline font-black tracking-tight text-lg ${className}`}>
-            <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">predicta</span>
+            <span className="text-indigo-600 dark:text-indigo-400">predicta</span>
             <span className="text-slate-900 dark:text-white">ball</span>
             <span className="ml-0.5 text-[10px] font-medium tracking-[0.2em] text-slate-500 dark:text-gray-400">.LIVE</span>
         </Link>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -13,6 +13,14 @@
     }
 }
 
+/* Faint film-grain texture. Dropped behind hero content (which sits at a higher
+   z-index) as a tiled SVG noise so large flat panels read as crafted rather
+   than the default-Tailwind smooth gradient wash. The opacity is baked low into
+   the tile so it stays a whisper in both themes. */
+.bg-grain {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
+}
+
 /* Chrome / Safari autofill overrides the input text colour to black, which is
    unreadable on our dark-mode inputs. The long inset box-shadow trick re-paints
    the autofill background; -webkit-text-fill-color overrides the autofill text

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,6 +9,7 @@ export default async function Home(): Promise<React.JSX.Element> {
     return (
         <main className="bg-slate-50 text-slate-900 dark:bg-gray-900 dark:text-white overflow-auto">
             <section className="relative flex flex-col p-10 h-svh">
+                <div aria-hidden className="pointer-events-none absolute inset-0 z-0 bg-grain opacity-70 dark:opacity-50"/>
                 <div className="absolute top-0 left-0 right-0 p-10 z-50">
                     <Header/>
                 </div>
@@ -36,17 +37,18 @@ export default async function Home(): Promise<React.JSX.Element> {
             </section>
 
             <section className="relative flex flex-col items-center px-6 lg:px-10 py-24 min-h-svh overflow-hidden">
-                <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.12),transparent_55%),radial-gradient(ellipse_at_bottom,rgba(34,197,94,0.10),transparent_55%)]"/>
+                <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(99,102,241,0.09),transparent_60%),radial-gradient(ellipse_at_bottom,rgba(139,92,246,0.05),transparent_60%)]"/>
+                <div aria-hidden className="pointer-events-none absolute inset-0 bg-grain opacity-70 dark:opacity-50"/>
                 <div className="pointer-events-none absolute inset-x-0 top-0 h-svh"><PitchPerspective/></div>
 
                 <HowItWorks>
-                    <div className="mt-24 relative overflow-hidden rounded-3xl bg-gradient-to-r from-blue-600/20 via-cyan-500/20 to-teal-400/20 p-[1px]">
-                        <div className="rounded-3xl bg-white dark:bg-gray-900/90 backdrop-blur-sm px-8 py-14 text-center">
+                    <div className="mt-24 relative overflow-hidden rounded-xl bg-gradient-to-r from-blue-600/20 via-cyan-500/20 to-teal-400/20 p-[1px]">
+                        <div className="rounded-xl bg-white dark:bg-gray-900/90 backdrop-blur-sm px-8 py-14 text-center">
                             <h3 className="font-display text-4xl lg:text-5xl font-black tracking-tight">
-                                Ready to <span className="bg-gradient-to-r from-blue-500 via-cyan-300 to-teal-300 bg-clip-text text-transparent">play</span>?
+                                Ready to <span className="text-indigo-600 dark:text-indigo-400">play</span>?
                             </h3>
                             <p className="mt-4 text-lg text-slate-600 dark:text-gray-300">Sign up now and start predicting.</p>
-                            <a href="/login" className="mt-8 inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-blue-600 via-cyan-400 to-teal-300 px-7 py-3 font-semibold text-gray-900 shadow-lg shadow-cyan-500/20 transition-transform hover:scale-105">
+                            <a href="/login" className="mt-8 inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-blue-600 via-cyan-400 to-teal-300 px-7 py-3 font-semibold text-white shadow-lg shadow-indigo-500/25 transition duration-200 hover:brightness-110">
                                 Get started
                                 <span>&rarr;</span>
                             </a>

--- a/frontend/app/util/css-classes.ts
+++ b/frontend/app/util/css-classes.ts
@@ -2,7 +2,7 @@
 // Single source of truth for the palette. To re-theme, change values here.
 //
 // Roles (kept distinct so no colour does double duty):
-//   brand     = blue → cyan → teal  (gradient + cyan for interactive/info)
+//   brand     = blue → indigo → violet  (gradient + indigo for interactive/info)
 //   positive  = emerald             (improved / gained)
 //   negative  = rose                (worsened / lost)
 //   live      = red                 (a match in play)
@@ -10,16 +10,21 @@
 //   warning   = amber
 // Green is intentionally NOT part of the brand gradient so it can mean
 // "positive" everywhere without ambiguity.
+//
+// NOTE: the `cyan-*` / `teal-*` utilities below (and throughout the app) are
+// re-pointed at indigo / violet in tailwind.config.ts, so they render as the
+// deeper brand band rather than literal cyan. New code can use `indigo-*` /
+// `violet-*` directly — they resolve to the same values.
 
-// Brand gradient stops (cool, green-free).
+// Brand gradient stops — blue → indigo → violet (cool, green-free, deliberate).
 export const BRAND_GRADIENT = "from-blue-500 via-cyan-400 to-teal-300"
 export const BRAND_TEXT_GRADIENT = `bg-gradient-to-r ${BRAND_GRADIENT} bg-clip-text text-transparent`
 
-export const BUTTON_CLASS = `bg-gradient-to-r ${BRAND_GRADIENT} text-gray-900 font-semibold shadow-lg shadow-cyan-500/20 transition-transform hover:scale-[1.02]`
+export const BUTTON_CLASS = `bg-gradient-to-r ${BRAND_GRADIENT} text-white font-semibold shadow-lg shadow-indigo-500/25 transition duration-200 hover:brightness-110`
 
 export const GHOST_BUTTON_CLASS = "bg-slate-900/5 border border-slate-900/10 text-slate-700 hover:bg-slate-900/10 hover:border-cyan-500/40 dark:bg-white/5 dark:border-white/10 dark:text-gray-200 dark:hover:bg-white/10 dark:hover:border-cyan-400/40 transition-colors"
 
-// Interactive / info accent (cyan).
+// Interactive / info accent (indigo — the `cyan-*` here renders as indigo).
 export const BRAND_GHOST_BUTTON_CLASS = "bg-cyan-500/10 border border-cyan-500/20 text-cyan-600 hover:bg-cyan-500/20 hover:border-cyan-500/40 dark:bg-cyan-400/10 dark:border-cyan-400/20 dark:text-cyan-300 dark:hover:bg-cyan-400/20 dark:hover:border-cyan-400/40 transition-colors"
 
 // Warm "action needed" accent (amber) — pops against the cool UI for calls-to-act.
@@ -30,7 +35,7 @@ export const ACTION_DOT = "bg-amber-500 dark:bg-amber-400"
 export const ACTION_PILL_BORDER = "bg-amber-500/40 hover:bg-amber-500/60 dark:bg-amber-400/40 dark:hover:bg-amber-400/60"
 // Primary call-to-action — solid warm amber/orange that pops against the cool
 // brand UI. Use for the single most important action on a surface.
-export const ACTION_BUTTON_CLASS = "bg-gradient-to-r from-amber-400 to-orange-500 text-gray-950 font-bold shadow-lg shadow-orange-500/25 transition-transform hover:scale-[1.01]"
+export const ACTION_BUTTON_CLASS = "bg-gradient-to-r from-amber-400 to-orange-500 text-gray-950 font-bold shadow-lg shadow-orange-500/25 transition duration-200 hover:brightness-105"
 
 // Podium glows for the top three leaderboard places. Each value is the
 // gradient "border" (revealed by the row's 1px padding) plus a coloured glow

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -12,6 +12,26 @@ const config: Config = {
     ],
     theme: {
         extend: {
+            // ── Brand re-skin ────────────────────────────────────────────────
+            // `cyan` and `teal` are used *exclusively* as the brand accent /
+            // gradient across the app (see util/css-classes.ts). The default
+            // pastel cyan→mint reads as a generic "AI template". We retire it by
+            // repointing those two scales at a deeper, more deliberate
+            // indigo → violet band — so every existing `cyan-*` / `teal-*`
+            // utility re-themes at once without touching call sites. `blue`
+            // stays real blue so the gradient reads blue → indigo → violet.
+            colors: {
+                cyan: {
+                    50: "#eef2ff", 100: "#e0e7ff", 200: "#c7d2fe", 300: "#a5b4fc",
+                    400: "#818cf8", 500: "#6366f1", 600: "#4f46e5", 700: "#4338ca",
+                    800: "#3730a3", 900: "#312e81", 950: "#1e1b4b",
+                },
+                teal: {
+                    50: "#f5f3ff", 100: "#ede9fe", 200: "#ddd6fe", 300: "#c4b5fd",
+                    400: "#a78bfa", 500: "#8b5cf6", 600: "#7c3aed", 700: "#6d28d9",
+                    800: "#5b21b6", 900: "#4c1d95", 950: "#2e1065",
+                },
+            },
             fontFamily: {
                 sans: ["var(--font-montserrat)", "ui-sans-serif", "system-ui", "sans-serif"],
                 display: ["var(--font-display)", "var(--font-montserrat)", "sans-serif"],


### PR DESCRIPTION
Retune the UI away from the default AI-template look while keeping the
existing layout and components intact:

- Retire the pastel blue→cyan→teal brand gradient. `cyan`/`teal` are used
  exclusively as brand accents, so repoint those two Tailwind scales at a
  deeper indigo→violet band — re-skinning every existing utility at once.
- Reduce gradient-text: the wordmark and section headings are now solid
  brand-indigo / ink instead of gradient fills, reserving the gradient for
  the hero word and primary buttons.
- Calmer surfaces: swap hover:scale micro-bounces on primary CTAs for a
  subtler brightness lift, and soften/retint the radial glow washes.
- Sharper details: tighten card corners (rounded-3xl → rounded-xl) and add
  a faint film-grain texture behind hero content so flat panels read as
  crafted rather than default-smooth.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017LjLXz364AEsvnoixq21qB